### PR TITLE
v0.8.1 완료

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dace.dmgr</groupId>
     <artifactId>DMGR</artifactId>
-    <version>0.8.0</version>
+    <version>0.8.1</version>
     <packaging>jar</packaging>
 
     <name>DMGR</name>

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceUlt.java
@@ -30,6 +30,7 @@ public final class ArkaceUlt extends UltimateSkill {
         super.onUse(actionKey);
 
         setDuration();
+        combatUser.getWeapon().onCancelled();
         ((ArkaceWeapon) combatUser.getWeapon()).getReloadModule().setRemainingAmmo(ArkaceWeaponInfo.CAPACITY);
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA2.java
@@ -144,7 +144,7 @@ public final class SiliaA2 extends ActiveSkill {
 
                 if (target instanceof Living && LocationUtil.canPass(combatUser.getEntity().getEyeLocation(), loc.clone().add(0, target.getEntity().getHeight() / 2, 0)) &&
                         (!(target instanceof CombatUser) || !((CombatUser) target).isDead())) {
-                    combatUser.getUser().teleport(loc);
+                    combatUser.teleport(loc);
                     combatUser.push(new Vector(0, 0.8, 0), true);
                     if (target instanceof CombatUser)
                         combatUser.addScore("적 띄움", SiliaA2Info.DAMAGE_SCORE);

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA2.java
@@ -205,13 +205,14 @@ public final class VellionA2 extends ActiveSkill {
                 combatUser.getMoveModule().getSpeedStatus().removeModifier(MODIFIER_ID);
                 Location loc = LocationUtil.getLocationFromOffset(combatUser.getEntity().getEyeLocation(), 0.2, -0.4, 0);
                 Location targetLoc = target.getEntity().getLocation().add(0, 1, 0);
+                target.getStatusEffectModule().applyStatusEffect(combatUser, vellionA2Mark, 4);
 
                 SoundUtil.playNamedSound(NamedSound.COMBAT_VELLION_A2_USE_READY, combatUser.getEntity().getLocation());
                 for (Location trailLoc : LocationUtil.getLine(loc, targetLoc, 0.4))
                     ParticleUtil.play(Particle.SPELL_WITCH, trailLoc, 1, 0, 0, 0, 0);
 
                 TaskUtil.addTask(VellionA2.this, new IntervalTask(i -> {
-                    if (isDurationFinished())
+                    if (isDurationFinished() || !target.getStatusEffectModule().hasStatusEffect(vellionA2Mark))
                         return false;
 
                     isEnabled = true;

--- a/src/main/java/com/dace/dmgr/combat/entity/AbstractCombatEntity.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/AbstractCombatEntity.java
@@ -3,6 +3,7 @@ package com.dace.dmgr.combat.entity;
 import com.dace.dmgr.combat.entity.module.statuseffect.StatusEffectType;
 import com.dace.dmgr.combat.interaction.Hitbox;
 import com.dace.dmgr.game.Game;
+import com.dace.dmgr.user.User;
 import com.dace.dmgr.util.task.DelayTask;
 import com.dace.dmgr.util.task.IntervalTask;
 import com.dace.dmgr.util.task.TaskUtil;
@@ -11,6 +12,7 @@ import lombok.NonNull;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.Nullable;
@@ -154,5 +156,17 @@ public abstract class AbstractCombatEntity<T extends Entity> implements CombatEn
     @Override
     public final void push(@NonNull Vector velocity) {
         push(velocity, false);
+    }
+
+    @Override
+    public final void teleport(@NonNull Location location) {
+        if (getStatusEffectModule().hasStatusEffectType(StatusEffectType.SNARE) || getStatusEffectModule().hasStatusEffectType(StatusEffectType.GROUNDING))
+            return;
+
+        if (entity instanceof Player) {
+            User user = User.fromPlayer((Player) entity);
+            user.teleport(location);
+        } else
+            entity.teleport(location);
     }
 }

--- a/src/main/java/com/dace/dmgr/combat/entity/CombatEntity.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/CombatEntity.java
@@ -151,6 +151,13 @@ public interface CombatEntity extends Disposable {
     void push(@NonNull Vector velocity);
 
     /**
+     * 엔티티를 지정한 위치로 순간이동 시킨다.
+     *
+     * @param location 이동할 위치
+     */
+    void teleport(@NonNull Location location);
+
+    /**
      * 다른 엔티티가 이 엔티티를 대상으로 지정할 수 있는 지 확인한다.
      *
      * @return 지정할 수 있으면 {@code true} 반환

--- a/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
@@ -1276,6 +1276,13 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
     public void cancelAction() {
         if (weapon.isCancellable())
             weapon.onCancelled();
+        cancelSkill();
+    }
+
+    /**
+     * 사용 중인 모든 스킬을 강제로 취소시킨다.
+     */
+    public void cancelSkill() {
         skillMap.forEach((skillInfo, skill) -> {
             if (skill.isCancellable())
                 skill.onCancelled();

--- a/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
@@ -223,7 +223,7 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
         super.activate();
 
         for (CombatEntity combatEntity : game == null ? CombatEntity.getAllExcluded() : game.getAllCombatEntities()) {
-            if (combatEntity instanceof Damageable)
+            if (combatEntity instanceof Damageable && combatEntity.isEnemy(this))
                 HologramUtil.setHologramVisibility(DamageModule.HEALTH_HOLOGRAM_ID + combatEntity, false, entity);
 
             if (combatEntity instanceof CombatUser)

--- a/src/main/java/com/dace/dmgr/combat/entity/module/StatusEffectModule.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/module/StatusEffectModule.java
@@ -61,7 +61,7 @@ public final class StatusEffectModule {
      * @param duration     지속시간 (tick)
      */
     public void applyStatusEffect(@NonNull CombatEntity provider, @NonNull StatusEffect statusEffect, long duration) {
-        long finalDuration = (long) (duration * (Math.max(0, 2 - resistanceStatus.getValue())));
+        long finalDuration = statusEffect.isPositive() ? duration : (long) (duration * (Math.max(0, 2 - resistanceStatus.getValue())));
         if (finalDuration == 0)
             return;
 

--- a/src/main/java/com/dace/dmgr/combat/entity/module/statuseffect/Silence.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/module/statuseffect/Silence.java
@@ -35,7 +35,7 @@ public class Silence implements StatusEffect {
         if (provider instanceof CombatUser && !((CombatUser) combatEntity).isDead() &&
                 ((CombatUser) combatEntity).getSkill(((CombatUser) combatEntity).getCharacterType().getCharacter().getUltimateSkillInfo()).isCancellable())
             ((CombatUser) provider).addScore("궁극기 차단", CombatUser.ULT_BLOCK_KILL_SCORE);
-        ((CombatUser) combatEntity).cancelAction();
+        ((CombatUser) combatEntity).cancelSkill();
     }
 
     @Override


### PR DESCRIPTION
## 알려진 버그 수정
- 인게임에서 아군의 생명력 홀로그램이 표시되지 않는 버그 수정 (#168)
- 상태 효과 저항력이 이로운 효과에도 적용되는 버그 수정 (#169)
- '아케이스' 궁극기 사용 시 재장전이 취소되지 않는 버그 수정
- 속박 또는 고정 상태이상이 걸린 상태에서 순간이동이 가능한 버그 수정
- 침묵 상태이상이 무기 사용을 차단하는 버그 수정
- '벨리온' 액티브 2번 - 상태이상 초기화 효과로 사라지지 않는 버그 수정