### PR TITLE
v0.8 밸런스 패치

### DIFF
--- a/src/main/java/com/dace/dmgr/combat/character/arkace/Arkace.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/Arkace.java
@@ -1,6 +1,7 @@
 package com.dace.dmgr.combat.character.arkace;
 
 import com.dace.dmgr.combat.CombatUtil;
+import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.TextIcon;
 import com.dace.dmgr.combat.action.info.ActiveSkillInfo;
 import com.dace.dmgr.combat.action.info.PassiveSkillInfo;
@@ -136,6 +137,14 @@ public final class Arkace extends Marksman {
     }
 
     @Override
+    public void onTick(@NonNull CombatUser combatUser, long i) {
+        super.onTick(combatUser, i);
+
+        if (combatUser.getEntity().isSprinting())
+            combatUser.useAction(ActionKey.PERIODIC_1);
+    }
+
+    @Override
     public void onDamage(@NonNull CombatUser victim, @Nullable Attacker attacker, int damage, @NonNull DamageType damageType, Location location, boolean isCrit) {
         CombatUtil.playBleedingEffect(location, victim.getEntity(), damage);
     }
@@ -160,7 +169,7 @@ public final class Arkace extends Marksman {
 
     @Override
     public boolean canSprint(@NonNull CombatUser combatUser) {
-        return !((ArkaceWeapon) combatUser.getWeapon()).getReloadModule().isReloading();
+        return true;
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceP1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceP1.java
@@ -3,9 +3,14 @@ package com.dace.dmgr.combat.character.arkace.action;
 import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.skill.AbstractSkill;
 import com.dace.dmgr.combat.entity.CombatUser;
+import com.dace.dmgr.util.CooldownUtil;
+import com.dace.dmgr.util.task.IntervalTask;
+import com.dace.dmgr.util.task.TaskUtil;
 import lombok.NonNull;
 
 public final class ArkaceP1 extends AbstractSkill {
+    /** 쿨타임 ID */
+    public static final String COOLDOWN_ID = "ArkaceP1";
     /** 수정자 ID */
     private static final String MODIFIER_ID = "ArkaceP1";
 
@@ -16,7 +21,7 @@ public final class ArkaceP1 extends AbstractSkill {
     @Override
     @NonNull
     public ActionKey @NonNull [] getDefaultActionKeys() {
-        return new ActionKey[]{ActionKey.SPRINT};
+        return new ActionKey[]{ActionKey.PERIODIC_1};
     }
 
     @Override
@@ -30,18 +35,25 @@ public final class ArkaceP1 extends AbstractSkill {
     }
 
     @Override
+    public boolean canUse() {
+        return super.canUse() && isDurationFinished() && !((ArkaceWeapon) combatUser.getWeapon()).getReloadModule().isReloading() &&
+                CooldownUtil.getCooldown(combatUser, COOLDOWN_ID) == 0;
+    }
+
+    @Override
     public void onUse(@NonNull ActionKey actionKey) {
-        if (isDurationFinished() && !combatUser.getEntity().isSprinting()) {
-            setDuration();
-            combatUser.getMoveModule().getSpeedStatus().addModifier(MODIFIER_ID, ArkaceP1Info.SPRINT_SPEED);
-            combatUser.getWeapon().displayDurability(ArkaceWeaponInfo.RESOURCE.SPRINT);
-        } else
-            onCancelled();
+        setDuration();
+        combatUser.getMoveModule().getSpeedStatus().addModifier(MODIFIER_ID, ArkaceP1Info.SPRINT_SPEED);
+        combatUser.getWeapon().displayDurability(ArkaceWeaponInfo.RESOURCE.SPRINT);
+
+        TaskUtil.addTask(taskRunner, new IntervalTask(i -> combatUser.getEntity().isSprinting() &&
+                !((ArkaceWeapon) combatUser.getWeapon()).getReloadModule().isReloading() && CooldownUtil.getCooldown(combatUser, COOLDOWN_ID) == 0,
+                isCancelled -> onCancelled(), 1));
     }
 
     @Override
     public boolean isCancellable() {
-        return !isDurationFinished() && combatUser.getEntity().isSprinting();
+        return !isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeapon.java
@@ -65,7 +65,11 @@ public final class ArkaceWeapon extends AbstractWeapon implements Reloadable, Fu
 
                 Location loc = combatUser.getEntity().getLocation();
                 if (combatUser.getSkill(ArkaceUltInfo.getInstance()).isDurationFinished()) {
-                    Vector dir = VectorUtil.getSpreadedVector(combatUser.getEntity().getLocation().getDirection(), fullAutoModule.increaseSpread());
+                    double spread = fullAutoModule.increaseSpread();
+                    if (combatUser.getEntity().isSprinting())
+                        spread *= ArkaceWeaponInfo.SPREAD.SPRINT_MULTIPLIER;
+
+                    Vector dir = VectorUtil.getSpreadedVector(combatUser.getEntity().getLocation().getDirection(), spread);
                     new ArkaceWeaponHitscan(false).shoot(dir);
                     reloadModule.consume(1);
 

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeapon.java
@@ -56,7 +56,7 @@ public final class ArkaceWeapon extends AbstractWeapon implements Reloadable, Fu
                     return;
                 }
 
-                CooldownUtil.setCooldown(combatUser, CombatUser.Cooldown.WEAPON_NO_SPRINT.getId(), CombatUser.Cooldown.WEAPON_NO_SPRINT.getDuration());
+                CooldownUtil.setCooldown(combatUser, ArkaceP1.COOLDOWN_ID, ArkaceWeaponInfo.SPRINT_READY_DURATION + 2);
 
                 if (!combatUser.getSkill(ArkaceP1Info.getInstance()).isDurationFinished()) {
                     setCooldown(ArkaceWeaponInfo.SPRINT_READY_DURATION);

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeapon.java
@@ -65,8 +65,8 @@ public final class ArkaceWeapon extends AbstractWeapon implements Reloadable, Fu
 
                 Location loc = combatUser.getEntity().getLocation();
                 if (combatUser.getSkill(ArkaceUltInfo.getInstance()).isDurationFinished()) {
-                    double spread = fullAutoModule.increaseSpread();
-                    if (combatUser.getEntity().isSprinting())
+                    double spread = combatUser.isMoving() ? fullAutoModule.increaseSpread() : 0;
+                    if (combatUser.getEntity().isSprinting() || !combatUser.getEntity().isOnGround())
                         spread *= ArkaceWeaponInfo.SPREAD.SPRINT_MULTIPLIER;
 
                     Vector dir = VectorUtil.getSpreadedVector(combatUser.getEntity().getLocation().getDirection(), spread);

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeaponInfo.java
@@ -60,6 +60,8 @@ public final class ArkaceWeaponInfo extends WeaponInfo {
      * 탄퍼짐 정보.
      */
     public interface SPREAD {
+        /** 달리기 탄퍼짐 배수 */
+        double SPRINT_MULTIPLIER = 1.5;
         /** 탄퍼짐 증가량 */
         double INCREMENT = 0.3;
         /** 탄퍼짐 시작 시점 */

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceWeaponInfo.java
@@ -61,7 +61,7 @@ public final class ArkaceWeaponInfo extends WeaponInfo {
      */
     public interface SPREAD {
         /** 달리기 탄퍼짐 배수 */
-        double SPRINT_MULTIPLIER = 1.5;
+        double SPRINT_MULTIPLIER = 2;
         /** 탄퍼짐 증가량 */
         double INCREMENT = 0.3;
         /** 탄퍼짐 시작 시점 */

--- a/src/main/java/com/dace/dmgr/combat/character/inferno/Inferno.java
+++ b/src/main/java/com/dace/dmgr/combat/character/inferno/Inferno.java
@@ -153,7 +153,7 @@ public final class Inferno extends Vanguard {
 
     @Override
     public boolean canSprint(@NonNull CombatUser combatUser) {
-        return !((InfernoWeapon) combatUser.getWeapon()).getReloadModule().isReloading();
+        return true;
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/jager/Jager.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/Jager.java
@@ -180,7 +180,7 @@ public final class Jager extends Marksman {
 
     @Override
     public boolean canSprint(@NonNull CombatUser combatUser) {
-        return !((JagerWeaponL) combatUser.getWeapon()).getReloadModule().isReloading() && !((JagerWeaponL) combatUser.getWeapon()).getAimModule().isAiming();
+        return !((JagerWeaponL) combatUser.getWeapon()).getAimModule().isAiming();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/jager/Jager.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/Jager.java
@@ -11,7 +11,6 @@ import com.dace.dmgr.combat.character.jager.action.*;
 import com.dace.dmgr.combat.entity.Attacker;
 import com.dace.dmgr.combat.entity.CombatUser;
 import com.dace.dmgr.combat.entity.Damageable;
-import com.dace.dmgr.combat.entity.Living;
 import com.dace.dmgr.combat.interaction.DamageType;
 import com.dace.dmgr.util.CooldownUtil;
 import com.dace.dmgr.util.StringFormUtil;
@@ -136,12 +135,7 @@ public final class Jager extends Marksman {
 
     @Override
     public boolean onAttack(@NonNull CombatUser attacker, @NonNull Damageable victim, int damage, @NonNull DamageType damageType, boolean isCrit) {
-        JagerA1 skill1 = (JagerA1) attacker.getSkill(JagerA1Info.getInstance());
         JagerUlt skillUlt = (JagerUlt) attacker.getSkill(JagerUltInfo.getInstance());
-
-        if (skill1.getSummonEntity() != null && victim instanceof Living)
-            skill1.getSummonEntity().getEntity().setTarget(victim.getEntity());
-
         return skillUlt.getSummonEntity() == null;
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/Jager.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/Jager.java
@@ -1,7 +1,6 @@
 package com.dace.dmgr.combat.character.jager;
 
 import com.dace.dmgr.combat.CombatUtil;
-import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.TextIcon;
 import com.dace.dmgr.combat.action.info.ActiveSkillInfo;
 import com.dace.dmgr.combat.action.info.PassiveSkillInfo;
@@ -133,14 +132,6 @@ public final class Jager extends Marksman {
             text.add(skill3.getSkillInfo() + "  §7[" + skill3.getDefaultActionKeys()[0].getName() + "] §f투척");
 
         return text.toString();
-    }
-
-    @Override
-    public void onTick(@NonNull CombatUser combatUser, long i) {
-        super.onTick(combatUser, i);
-
-        if (i % 5 == 0)
-            combatUser.useAction(ActionKey.PERIODIC_1);
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA1Info.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA1Info.java
@@ -13,15 +13,15 @@ public final class JagerA1Info extends ActiveSkillInfo {
     /** 소환 최대 거리 (단위: 블록) */
     public static final int SUMMON_MAX_DISTANCE = 15;
     /** 소환 시간 (tick) */
-    public static final long SUMMON_DURATION = 1 * 20;
+    public static final long SUMMON_DURATION = 2 * 20;
     /** 체력 */
-    public static final int HEALTH = 600;
+    public static final int HEALTH = 500;
     /** 피해량 */
     public static final int DAMAGE = 150;
     /** 이동속도 */
     public static final double SPEED = 0.45;
-    /** 치명상 감지 범위 (단위: 블록) */
-    public static final double LOW_HEALTH_DETECT_RADIUS = 20;
+    /** 적 감지 범위 (단위: 블록) */
+    public static final double ENEMY_DETECT_RADIUS = 20;
     /** 체력 최대 회복 시간 (tick) */
     public static final int RECOVER_DURATION = 6 * 20;
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA2.java
@@ -223,9 +223,9 @@ public final class JagerA2 extends ActiveSkill {
         public void onAttack(@NonNull Damageable victim, int damage, @NonNull DamageType damageType, boolean isCrit, boolean isUlt) {
             owner.onAttack(victim, damage, damageType, isCrit, isUlt);
 
-            JagerA1 skill1 = (JagerA1) owner.getSkill(JagerA1Info.getInstance());
-            if (skill1.getSummonEntity() != null && skill1.getSummonEntity().getEntity().getTarget() == null)
-                skill1.getSummonEntity().getEntity().setTarget(victim.getEntity());
+            JagerP1 skillp1 = (JagerP1) combatUser.getSkill(JagerP1Info.getInstance());
+            skillp1.setTarget(victim);
+            combatUser.useAction(ActionKey.PERIODIC_1);
         }
 
         @Override

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA3.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA3.java
@@ -223,12 +223,14 @@ public final class JagerA3 extends ActiveSkill {
 
                 if (target.getPropertyManager().getValue(Property.FREEZE) >= JagerT1Info.MAX) {
                     target.getStatusEffectModule().applyStatusEffect(combatUser, Freeze.instance, JagerA3Info.SNARE_DURATION);
-                    if (target != combatUser && target instanceof CombatUser)
-                        combatUser.addScore("적 얼림", JagerA3Info.SNARE_SCORE);
+                    if (target != combatUser) {
+                        if (target instanceof CombatUser)
+                            combatUser.addScore("적 얼림", JagerA3Info.SNARE_SCORE);
 
-                    JagerP1 skillp1 = (JagerP1) combatUser.getSkill(JagerP1Info.getInstance());
-                    skillp1.setTarget(target);
-                    combatUser.useAction(ActionKey.PERIODIC_1);
+                        JagerP1 skillp1 = (JagerP1) combatUser.getSkill(JagerP1Info.getInstance());
+                        skillp1.setTarget(target);
+                        combatUser.useAction(ActionKey.PERIODIC_1);
+                    }
                 }
             }
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA3.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA3.java
@@ -225,6 +225,10 @@ public final class JagerA3 extends ActiveSkill {
                     target.getStatusEffectModule().applyStatusEffect(combatUser, Freeze.instance, JagerA3Info.SNARE_DURATION);
                     if (target != combatUser && target instanceof CombatUser)
                         combatUser.addScore("적 얼림", JagerA3Info.SNARE_SCORE);
+
+                    JagerP1 skillp1 = (JagerP1) combatUser.getSkill(JagerP1Info.getInstance());
+                    skillp1.setTarget(target);
+                    combatUser.useAction(ActionKey.PERIODIC_1);
                 }
             }
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerP1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerP1.java
@@ -1,17 +1,18 @@
 package com.dace.dmgr.combat.character.jager.action;
 
-import com.dace.dmgr.combat.CombatUtil;
 import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.skill.AbstractSkill;
 import com.dace.dmgr.combat.entity.CombatUser;
 import com.dace.dmgr.combat.entity.Damageable;
-import com.dace.dmgr.util.task.IntervalTask;
-import com.dace.dmgr.util.task.TaskUtil;
+import com.dace.dmgr.util.GlowUtil;
 import lombok.NonNull;
+import lombok.Setter;
+import org.bukkit.ChatColor;
 
+@Setter
 public final class JagerP1 extends AbstractSkill {
-    /** 수정자 ID */
-    private static final String MODIFIER_ID = "JagerP1";
+    /** 현재 사용 대상 */
+    private Damageable target = null;
 
     JagerP1(@NonNull CombatUser combatUser) {
         super(combatUser, JagerP1Info.getInstance());
@@ -34,48 +35,12 @@ public final class JagerP1 extends AbstractSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && canActivate();
-    }
-
-    /**
-     * 스킬 활성화 조건을 확인한다.
-     *
-     * @return 활성화 조건
-     */
-    private boolean canActivate() {
-        JagerA1 skill1 = (JagerA1) combatUser.getSkill(JagerA1Info.getInstance());
-
-        if (!skill1.isDurationFinished() && skill1.getSummonEntity() != null) {
-            JagerA1.JagerA1Entity jagerA1Entity = skill1.getSummonEntity();
-
-            Damageable target = (Damageable) CombatUtil.getNearCombatEntity(combatUser.getGame(), combatUser.getEntity().getLocation(),
-                    JagerP1Info.DETECT_RADIUS, combatEntity -> combatEntity == jagerA1Entity);
-
-            return target != null;
-        }
-
-        return false;
-    }
-
-    @Override
     public void onUse(@NonNull ActionKey actionKey) {
-        setDuration();
-        combatUser.getMoveModule().getSpeedStatus().addModifier(MODIFIER_ID, JagerP1Info.SPEED);
-
-        TaskUtil.addTask(taskRunner, new IntervalTask(i -> canActivate(), isCancelled -> onCancelled(), 1));
+        GlowUtil.setGlowing(target.getEntity(), ChatColor.RED, combatUser.getEntity(), JagerP1Info.DURATION);
     }
 
     @Override
     public boolean isCancellable() {
-        return !isDurationFinished();
-    }
-
-    @Override
-    public void onCancelled() {
-        super.onCancelled();
-
-        setDuration(0);
-        combatUser.getMoveModule().getSpeedStatus().removeModifier(MODIFIER_ID);
+        return false;
     }
 }

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerP1Info.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerP1Info.java
@@ -6,10 +6,8 @@ import lombok.Getter;
 import lombok.NonNull;
 
 public final class JagerP1Info extends PassiveSkillInfo {
-    /** 이동속도 증가량 */
-    public static final int SPEED = 15;
-    /** 감지 범위 (단위: 블록) */
-    public static final double DETECT_RADIUS = 10;
+    /** 지속시간 (tick) */
+    public static final long DURATION = 3 * 20;
     @Getter
     private static final JagerP1Info instance = new JagerP1Info();
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponInfo.java
@@ -16,9 +16,9 @@ public final class JagerWeaponInfo extends WeaponInfo {
     /** 투사체 속력 (단위: 블록/s) */
     public static final int VELOCITY = 80;
     /** 탄퍼짐 */
-    public static final double SPREAD = 3;
+    public static final double SPREAD = 2.5;
     /** 달리기 탄퍼짐 배수 */
-    public static final double SPREAD_SPRINT_MULTIPLIER = 1.5;
+    public static final double SPREAD_SPRINT_MULTIPLIER = 2.5;
     /** 빙결량 */
     public static final int FREEZE = 15;
     /** 장탄수 */
@@ -66,9 +66,9 @@ public final class JagerWeaponInfo extends WeaponInfo {
             /** 수평 반동 */
             double SIDE = 0;
             /** 수직 반동 분산도 */
-            double UP_SPREAD = 0.3;
+            double UP_SPREAD = 0.25;
             /** 수평 반동 분산도 */
-            double SIDE_SPREAD = 0.4;
+            double SIDE_SPREAD = 0.3;
         }
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponInfo.java
@@ -16,7 +16,9 @@ public final class JagerWeaponInfo extends WeaponInfo {
     /** 투사체 속력 (단위: 블록/s) */
     public static final int VELOCITY = 80;
     /** 탄퍼짐 */
-    public static final double SPREAD = 5;
+    public static final double SPREAD = 3;
+    /** 달리기 탄퍼짐 배수 */
+    public static final double SPREAD_SPRINT_MULTIPLIER = 1.5;
     /** 빙결량 */
     public static final int FREEZE = 15;
     /** 장탄수 */

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponInfo.java
@@ -12,9 +12,9 @@ public final class JagerWeaponInfo extends WeaponInfo {
     /** 피해량 */
     public static final int DAMAGE = 100;
     /** 사거리 (단위: 블록) */
-    public static final int DISTANCE = 20;
+    public static final int DISTANCE = 30;
     /** 투사체 속력 (단위: 블록/s) */
-    public static final int VELOCITY = 80;
+    public static final int VELOCITY = 100;
     /** 탄퍼짐 */
     public static final double SPREAD = 2.5;
     /** 달리기 탄퍼짐 배수 */
@@ -22,7 +22,7 @@ public final class JagerWeaponInfo extends WeaponInfo {
     /** 빙결량 */
     public static final int FREEZE = 15;
     /** 장탄수 */
-    public static final int CAPACITY = 8;
+    public static final int CAPACITY = 10;
     /** 재장전 시간 (tick) */
     public static final long RELOAD_DURATION = 2 * 20;
     /** 무기 교체 시간 (tick) */
@@ -49,11 +49,11 @@ public final class JagerWeaponInfo extends WeaponInfo {
         /** 쿨타임 (tick) */
         long COOLDOWN = (long) (0.25 * 20);
         /** 피해량 */
-        int DAMAGE = 250;
+        int DAMAGE = 240;
         /** 피해량 감소 시작 거리 (단위: 블록) */
         int DAMAGE_WEAKENING_DISTANCE = 30;
         /** 장탄수 */
-        int CAPACITY = 6;
+        int CAPACITY = 7;
         /** 확대 레벨 */
         Aimable.ZoomLevel ZOOM_LEVEL = Aimable.ZoomLevel.L4;
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
@@ -71,8 +71,8 @@ public final class JagerWeaponL extends AbstractWeapon implements Reloadable, Sw
 
                 setCooldown();
 
-                double spread = JagerWeaponInfo.SPREAD;
-                if (combatUser.getEntity().isSprinting())
+                double spread = combatUser.isMoving() ? JagerWeaponInfo.SPREAD : 0;
+                if (combatUser.getEntity().isSprinting() || !combatUser.getEntity().isOnGround())
                     spread *= JagerWeaponInfo.SPREAD_SPRINT_MULTIPLIER;
 
                 Vector dir = VectorUtil.getSpreadedVector(combatUser.getEntity().getLocation().getDirection(), spread);

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
@@ -70,7 +70,6 @@ public final class JagerWeaponL extends AbstractWeapon implements Reloadable, Sw
                 }
 
                 setCooldown();
-                CooldownUtil.setCooldown(combatUser, CombatUser.Cooldown.WEAPON_NO_SPRINT.getId(), CombatUser.Cooldown.WEAPON_NO_SPRINT.getDuration());
 
                 Vector dir = VectorUtil.getSpreadedVector(combatUser.getEntity().getLocation().getDirection(), JagerWeaponInfo.SPREAD);
                 new JagerWeaponLProjectile().shoot(dir);

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
@@ -71,7 +71,11 @@ public final class JagerWeaponL extends AbstractWeapon implements Reloadable, Sw
 
                 setCooldown();
 
-                Vector dir = VectorUtil.getSpreadedVector(combatUser.getEntity().getLocation().getDirection(), JagerWeaponInfo.SPREAD);
+                double spread = JagerWeaponInfo.SPREAD;
+                if (combatUser.getEntity().isSprinting())
+                    spread *= JagerWeaponInfo.SPREAD_SPRINT_MULTIPLIER;
+
+                Vector dir = VectorUtil.getSpreadedVector(combatUser.getEntity().getLocation().getDirection(), spread);
                 new JagerWeaponLProjectile().shoot(dir);
                 reloadModule.consume(1);
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponR.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponR.java
@@ -10,7 +10,10 @@ import com.dace.dmgr.combat.entity.Damageable;
 import com.dace.dmgr.combat.interaction.DamageType;
 import com.dace.dmgr.combat.interaction.GunHitscan;
 import com.dace.dmgr.combat.interaction.HitscanOption;
-import com.dace.dmgr.util.*;
+import com.dace.dmgr.util.LocationUtil;
+import com.dace.dmgr.util.NamedSound;
+import com.dace.dmgr.util.ParticleUtil;
+import com.dace.dmgr.util.SoundUtil;
 import lombok.Getter;
 import lombok.NonNull;
 import org.bukkit.Location;
@@ -56,7 +59,6 @@ public final class JagerWeaponR extends AbstractWeapon implements Reloadable {
                 }
 
                 setCooldown();
-                CooldownUtil.setCooldown(combatUser, CombatUser.Cooldown.WEAPON_NO_SPRINT.getId(), CombatUser.Cooldown.WEAPON_NO_SPRINT.getDuration());
 
                 new JagerWeaponRHitscan().shoot();
                 reloadModule.consume(1);

--- a/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceWeapon.java
@@ -101,7 +101,7 @@ public final class NeaceWeapon extends AbstractWeapon implements FullAuto {
     void healTarget(Healable target) {
         boolean isAmplifying = !combatUser.getSkill(NeaceA2Info.getInstance()).isDurationFinished();
 
-        target.getDamageModule().heal(combatUser, NeaceWeaponInfo.HEAL.HEAL_PER_SECOND / 20, true);
+        target.getDamageModule().heal(combatUser, (NeaceWeaponInfo.HEAL.HEAL_PER_SECOND / (isAmplifying ? 40 : 20)), true);
         if (isAmplifying) {
             target.getStatusEffectModule().applyStatusEffect(combatUser, NeaceA2.NeaceA2Buff.instance, 4);
             if (target instanceof CombatUser)

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA2.java
@@ -130,8 +130,6 @@ public final class SiliaA2 extends ActiveSkill {
 
         @Override
         protected boolean onHitEntity(@NonNull Damageable target, boolean isCrit) {
-            setCooldown(getDefaultCooldown() / 2);
-
             if (target.getDamageModule().damage(this, SiliaA2Info.DAMAGE, DamageType.NORMAL, location,
                     SiliaT1.isBackAttack(velocity, target) ? SiliaT1Info.CRIT_MULTIPLIER : 1, true)) {
                 target.getKnockbackModule().knockback(new Vector(0, SiliaA2Info.PUSH, 0), true);

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA2Info.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA2Info.java
@@ -7,7 +7,7 @@ import lombok.NonNull;
 
 public final class SiliaA2Info extends ActiveSkillInfo {
     /** 쿨타임 (tick) */
-    public static final long COOLDOWN = 14 * 20;
+    public static final long COOLDOWN = 11 * 20;
     /** 전역 쿨타임 (tick) */
     public static final int GLOBAL_COOLDOWN = 1 * 20;
     /** 시전 시간 (tick) */

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaWeaponInfo.java
@@ -13,7 +13,7 @@ public final class SiliaWeaponInfo extends WeaponInfo {
     /** 투사체 속력 (단위: 블록/s) */
     public static final int VELOCITY = 35;
     /** 투사체 크기 (단위: 블록) */
-    public static final double SIZE = 0.5;
+    public static final double SIZE = 0.4;
     /** 쿨타임 (tick) */
     public static final long COOLDOWN = (long) (0.9 * 20);
     @Getter

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionUltInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionUltInfo.java
@@ -13,7 +13,7 @@ public final class VellionUltInfo extends UltimateSkillInfo {
     /** 효과 범위 (단위: 블록) */
     public static final double RADIUS = 8;
     /** 이동 속도 감소량 */
-    public static final int SLOW = 30;
+    public static final int SLOW = 50;
     /** 지속시간 (tick) */
     public static final long DURATION = (long) (2.5 * 20);
     /** 피해량 비율 */

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionWeaponInfo.java
@@ -11,7 +11,7 @@ public final class VellionWeaponInfo extends WeaponInfo {
     /** 피해량 */
     public static final int DAMAGE = 120;
     /** 사거리 (단위: 블록) */
-    public static final int DISTANCE = 20;
+    public static final int DISTANCE = 30;
     /** 투사체 속력 (단위: 블록/s) */
     public static final int VELOCITY = 35;
     /** 투사체 크기 (단위: 블록) */

--- a/src/main/java/com/dace/dmgr/combat/entity/AbstractCombatEntity.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/AbstractCombatEntity.java
@@ -44,6 +44,8 @@ public abstract class AbstractCombatEntity<T extends Entity> implements CombatEn
     protected final Hitbox @NonNull [] hitboxes;
     /** 활성화 여부 */
     protected boolean isActivated = false;
+    /** 움직임 상태 */
+    protected boolean isMoving = false;
     /** 히트박스의 중앙 위치 */
     @NonNull
     private Location hitboxLocation;
@@ -109,6 +111,7 @@ public abstract class AbstractCombatEntity<T extends Entity> implements CombatEn
         Location oldLoc = entity.getLocation();
 
         TaskUtil.addTask(this, new DelayTask(() -> {
+            isMoving = oldLoc.distance(entity.getLocation()) > 0;
             for (Hitbox hitbox : getHitboxes()) {
                 hitboxLocation = oldLoc;
                 hitbox.setCenter(hitboxLocation);

--- a/src/main/java/com/dace/dmgr/combat/entity/CombatEntity.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/CombatEntity.java
@@ -144,6 +144,13 @@ public interface CombatEntity extends Disposable {
     boolean isEnemy(@NonNull CombatEntity combatEntity);
 
     /**
+     * 엔티티가 움직이고 있는 지 확인한다.
+     *
+     * @return 움직이고 있으면 {@code true} 반환
+     */
+    boolean isMoving();
+
+    /**
      * 엔티티를 지정한 속도로 밀어낸다. (이동기).
      *
      * @param velocity 속도

--- a/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
@@ -507,8 +507,6 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
         if (statusEffectModule.hasStatusEffectType(StatusEffectType.STUN) || statusEffectModule.hasStatusEffectType(StatusEffectType.SNARE) ||
                 statusEffectModule.hasStatusEffectType(StatusEffectType.GROUNDING))
             return false;
-        if (CooldownUtil.getCooldown(this, Cooldown.WEAPON_NO_SPRINT.id) > 0)
-            return false;
         if (propertyManager.getValue(Property.FREEZE) >= JagerT1Info.NO_SPRINT)
             return false;
 
@@ -1385,8 +1383,6 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
         HEAL_PACK("HealPack", GeneralConfig.getCombatConfig().getHealPackCooldown()),
         /** 점프대 */
         JUMP_PAD("JumpPad", 10),
-        /** 무기 사용 시 달리기 금지 */
-        WEAPON_NO_SPRINT("WeaponNoSprint", 7),
         /** 적 타격 시 생명력 홀로그램 */
         HIT_HEALTH_HOLOGRAM("HitHealthHologram", 20),
         /** 적 처치 기여 (데미지 누적) 제한시간 */

--- a/src/main/java/com/dace/dmgr/util/NamedSound.java
+++ b/src/main/java/com/dace/dmgr/util/NamedSound.java
@@ -139,6 +139,8 @@ public enum NamedSound {
     ),
     /** 전투 - '예거' 액티브 1번 - 소환 준비 */
     COMBAT_JAGER_A1_SUMMON_READY(new DefinedSound(Sound.ENTITY_WOLF_GROWL, 1, 1)),
+    /** 전투 - '예거' 액티브 1번 - 적 감지 */
+    COMBAT_JAGER_A1_ENEMY_DETECT(new DefinedSound(Sound.ENTITY_WOLF_GROWL, 2, 0.85)),
     /** 전투 - '예거' 액티브 1번 - 피격 */
     COMBAT_JAGER_A1_DAMAGE(new DefinedSound(Sound.ENTITY_WOLF_HURT, 0.4, 1, 0.1)),
     /** 전투 - '예거' 액티브 1번 - 사망 */


### PR DESCRIPTION
### 전체
- 무기 사격 및 재장전 중 달리기가 취소되지 않도록 수정
- 가변 탄퍼짐 적용 - 정지, 걷기, 달리기(점프) 순으로 무기의 탄퍼짐이 증가함
### 예거
- 무기 - 냉각탄
  - 장탄수 8 -> 10
- 정조준(저격)
  - 장탄수 6 -> 7
  - 피해량 250 -> 240
- 패시브 1번
  - 효과 변경 - 설랑이 공격한 적, 곰덫에 걸린 적 및 빙결 수류탄으로 속박당한 적의 위치를 일정 시간동안 탐지합니다.
- 액티브 1번 - 설랑
  - 체력 600 -> 500
  - 설랑이 플레이어를 따라다니지 않음, 근처의 적을 감지하면 추적함
### 니스
- 액티브 2번
  - 사용 중 치유량이 절반으로 감소
### 실리아
- 무기
  - 투사체 크기 0.5 -> 0.4
- 액티브 2번
  - 적중 시 쿨타임 감소 제거
  - 쿨타임 14초 -> 11초
### 벨리온
- 무기
  - 사거리 20m -> 30m
- 궁극기
  - 이동 속도 감소 30% -> 50%