### PR TITLE
인게임 편의성 개편

### DIFF
--- a/src/main/java/com/dace/dmgr/combat/action/AbstractAction.java
+++ b/src/main/java/com/dace/dmgr/combat/action/AbstractAction.java
@@ -115,7 +115,7 @@ public abstract class AbstractAction implements Action {
     }
 
     @Override
-    public boolean canUse() {
+    public boolean canUse(@NonNull ActionKey actionKey) {
         return isCooldownFinished();
     }
 

--- a/src/main/java/com/dace/dmgr/combat/action/Action.java
+++ b/src/main/java/com/dace/dmgr/combat/action/Action.java
@@ -95,9 +95,10 @@ public interface Action extends Disposable {
     /**
      * 동작을 사용할 수 있는 지 확인한다.
      *
+     * @param actionKey 사용 키
      * @return 사용 가능 여부
      */
-    boolean canUse();
+    boolean canUse(@NonNull ActionKey actionKey);
 
     /**
      * 동작 사용 시 실행할 작업.

--- a/src/main/java/com/dace/dmgr/combat/action/MeleeAttackAction.java
+++ b/src/main/java/com/dace/dmgr/combat/action/MeleeAttackAction.java
@@ -52,9 +52,9 @@ public final class MeleeAttackAction extends AbstractAction {
     }
 
     @Override
-    public boolean canUse() {
+    public boolean canUse(@NonNull ActionKey actionKey) {
         Validate.notNull(combatUser.getCharacterType());
-        return super.canUse() && combatUser.getCharacterType().getCharacter().canUseMeleeAttack(combatUser) && combatUser.isGlobalCooldownFinished();
+        return super.canUse(actionKey) && combatUser.getCharacterType().getCharacter().canUseMeleeAttack(combatUser) && combatUser.isGlobalCooldownFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/action/skill/ActiveSkill.java
+++ b/src/main/java/com/dace/dmgr/combat/action/skill/ActiveSkill.java
@@ -1,5 +1,6 @@
 package com.dace.dmgr.combat.action.skill;
 
+import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.info.ActiveSkillInfo;
 import com.dace.dmgr.combat.entity.CombatUser;
 import com.dace.dmgr.util.CooldownUtil;
@@ -66,8 +67,8 @@ public abstract class ActiveSkill extends AbstractSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && combatUser.isGlobalCooldownFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && combatUser.isGlobalCooldownFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/action/skill/StackableSkill.java
+++ b/src/main/java/com/dace/dmgr/combat/action/skill/StackableSkill.java
@@ -1,5 +1,6 @@
 package com.dace.dmgr.combat.action.skill;
 
+import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.info.ActiveSkillInfo;
 import com.dace.dmgr.combat.entity.CombatUser;
 import com.dace.dmgr.util.CooldownUtil;
@@ -46,8 +47,8 @@ public abstract class StackableSkill extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && stack > 0;
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && stack > 0;
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/action/weapon/AbstractWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/action/weapon/AbstractWeapon.java
@@ -1,6 +1,7 @@
 package com.dace.dmgr.combat.action.weapon;
 
 import com.dace.dmgr.combat.action.AbstractAction;
+import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.info.WeaponInfo;
 import com.dace.dmgr.combat.entity.CombatUser;
 import lombok.NonNull;
@@ -36,8 +37,8 @@ public abstract class AbstractWeapon extends AbstractAction implements Weapon {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && combatUser.isGlobalCooldownFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && combatUser.isGlobalCooldownFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceA1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceA1.java
@@ -44,8 +44,8 @@ public final class ArkaceA1 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceA2.java
@@ -35,8 +35,8 @@ public final class ArkaceA2 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceP1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceP1.java
@@ -35,8 +35,8 @@ public final class ArkaceP1 extends AbstractSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && !((ArkaceWeapon) combatUser.getWeapon()).getReloadModule().isReloading() &&
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && !((ArkaceWeapon) combatUser.getWeapon()).getReloadModule().isReloading() &&
                 CooldownUtil.getCooldown(combatUser, COOLDOWN_ID) == 0;
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/arkace/action/ArkaceUlt.java
@@ -21,8 +21,8 @@ public final class ArkaceUlt extends UltimateSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/inferno/action/InfernoA1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/inferno/action/InfernoA1.java
@@ -40,8 +40,8 @@ public final class InfernoA1 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/inferno/action/InfernoA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/inferno/action/InfernoA2.java
@@ -42,8 +42,8 @@ public final class InfernoA2 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/inferno/action/InfernoUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/inferno/action/InfernoUlt.java
@@ -33,8 +33,8 @@ public final class InfernoUlt extends UltimateSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && combatUser.getSkill(InfernoA1Info.getInstance()).isDurationFinished() &&
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && combatUser.getSkill(InfernoA1Info.getInstance()).isDurationFinished() &&
                 combatUser.getSkill(InfernoA2Info.getInstance()).isDurationFinished();
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/inferno/action/InfernoWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/inferno/action/InfernoWeapon.java
@@ -56,6 +56,11 @@ public final class InfernoWeapon extends AbstractWeapon implements Reloadable, F
     }
 
     @Override
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return actionKey == ActionKey.DROP ? combatUser.isGlobalCooldownFinished() : super.canUse(actionKey);
+    }
+
+    @Override
     public void onUse(@NonNull ActionKey actionKey) {
         switch (actionKey) {
             case RIGHT_CLICK: {

--- a/src/main/java/com/dace/dmgr/combat/character/jager/Jager.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/Jager.java
@@ -130,7 +130,7 @@ public final class Jager extends Marksman {
             skill1Display += "  §7[" + skill1.getDefaultActionKeys()[0].getName() + "] §f회수";
         text.add(skill1Display);
         if (!skill3.isDurationFinished() && skill3.isEnabled())
-            text.add(JagerA3Info.getInstance() + "  §7[" + skill3.getDefaultActionKeys()[0].getName() + "] §f투척");
+            text.add(JagerA3Info.getInstance() + "  §7[" + skill3.getDefaultActionKeys()[0].getName() + "][" + skill3.getDefaultActionKeys()[1].getName() + "] §f투척");
 
         return text.toString();
     }

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA1.java
@@ -179,7 +179,7 @@ public final class JagerA1 extends ChargeableSkill implements Confirmable {
                     entity,
                     owner.getName() + "의 설랑",
                     owner,
-                    false,
+                    true, false,
                     new FixedPitchHitbox(entity.getLocation(), 0.4, 0.8, 1.2, 0, 0.4, 0)
             );
             knockbackModule = new KnockbackModule(this);

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA1.java
@@ -71,8 +71,8 @@ public final class JagerA1 extends ChargeableSkill implements Confirmable {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && combatUser.getSkill(JagerA3Info.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && combatUser.getSkill(JagerA3Info.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA1.java
@@ -135,7 +135,7 @@ public final class JagerA1 extends ChargeableSkill implements Confirmable {
 
         setDuration();
         confirmModule.toggleCheck();
-        combatUser.getWeapon().setCooldown(1);
+        combatUser.getWeapon().setCooldown(2);
 
         Wolf wolf = CombatUtil.spawnEntity(Wolf.class, confirmModule.getCurrentLocation());
         summonEntity = new JagerA1Entity(wolf, combatUser);

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA2.java
@@ -55,8 +55,8 @@ public final class JagerA2 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && !combatUser.getSkill(JagerA1Info.getInstance()).getConfirmModule().isChecking() &&
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && !combatUser.getSkill(JagerA1Info.getInstance()).getConfirmModule().isChecking() &&
                 combatUser.getSkill(JagerA3Info.getInstance()).isDurationFinished();
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA2.java
@@ -25,7 +25,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
-import org.bukkit.entity.MagmaCube;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.Nullable;
@@ -99,11 +99,42 @@ public final class JagerA2 extends ActiveSkill {
             summonEntity.dispose();
     }
 
+    private final class JagerA2Projectile extends BouncingProjectile {
+        private JagerA2Projectile() {
+            super(combatUser, JagerA2Info.VELOCITY, -1, ProjectileOption.builder().trailInterval(8).hasGravity(true)
+                    .condition(combatUser::isEnemy).build(), BouncingProjectileOption.builder().bounceVelocityMultiplier(0.35)
+                    .destroyOnHitFloor(true).build());
+        }
+
+        @Override
+        protected void onTrailInterval() {
+            ParticleUtil.playRGB(ParticleUtil.ColoredParticle.REDSTONE, getLocation(), 17,
+                    0.7, 0, 0.7, 120, 120, 135);
+        }
+
+        @Override
+        protected boolean onHitBlockBouncing(@NonNull Block hitBlock) {
+            return false;
+        }
+
+        @Override
+        protected boolean onHitEntityBouncing(@NonNull Damageable target, boolean isCrit) {
+            return false;
+        }
+
+        @Override
+        protected void onDestroy() {
+            ArmorStand armorStand = CombatUtil.spawnEntity(ArmorStand.class, getLocation());
+            summonEntity = new JagerA2Entity(armorStand, combatUser);
+            summonEntity.activate();
+        }
+    }
+
     /**
      * 곰덫 클래스.
      */
     @Getter
-    public final class JagerA2Entity extends SummonEntity<MagmaCube> implements HasReadyTime, Damageable, Attacker {
+    public final class JagerA2Entity extends SummonEntity<ArmorStand> implements HasReadyTime, Damageable, Attacker {
         /** 넉백 모듈 */
         @NonNull
         private final KnockbackModule knockbackModule;
@@ -120,12 +151,12 @@ public final class JagerA2 extends ActiveSkill {
         @NonNull
         private final ReadyTimeModule readyTimeModule;
 
-        private JagerA2Entity(@NonNull MagmaCube entity, @NonNull CombatUser owner) {
+        private JagerA2Entity(@NonNull ArmorStand entity, @NonNull CombatUser owner) {
             super(
                     entity,
                     owner.getName() + "의 곰덫",
                     owner,
-                    true,
+                    true, true,
                     new FixedPitchHitbox(entity.getLocation(), 0.8, 0.1, 0.8, 0, 0.05, 0)
             );
             knockbackModule = new KnockbackModule(this, 2);
@@ -139,10 +170,13 @@ public final class JagerA2 extends ActiveSkill {
 
         private void onInit() {
             entity.setAI(false);
-            entity.setSize(1);
-            entity.setSilent(true);
             entity.setInvulnerable(true);
-            entity.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 0, false, false), true);
+            entity.setSilent(true);
+            entity.setMarker(true);
+            entity.setSmall(true);
+            entity.setVisible(false);
+            entity.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 0, false,
+                    false), true);
             entity.teleport(entity.getLocation().add(0, 0.05, 0));
             damageModule.setMaxHealth(JagerA2Info.HEALTH);
             damageModule.setHealth(JagerA2Info.HEALTH);
@@ -251,37 +285,6 @@ public final class JagerA2 extends ActiveSkill {
             ParticleUtil.playBlock(ParticleUtil.BlockParticle.BLOCK_DUST, Material.IRON_BLOCK, 0, entity.getLocation(), 80,
                     0.1, 0.1, 0.1, 0.15);
             SoundUtil.playNamedSound(NamedSound.COMBAT_JAGER_A2_DEATH, entity.getLocation());
-        }
-    }
-
-    private final class JagerA2Projectile extends BouncingProjectile {
-        private JagerA2Projectile() {
-            super(combatUser, JagerA2Info.VELOCITY, -1, ProjectileOption.builder().trailInterval(8).hasGravity(true)
-                    .condition(combatUser::isEnemy).build(), BouncingProjectileOption.builder().bounceVelocityMultiplier(0.35)
-                    .destroyOnHitFloor(true).build());
-        }
-
-        @Override
-        protected void onTrailInterval() {
-            ParticleUtil.playRGB(ParticleUtil.ColoredParticle.REDSTONE, getLocation(), 17,
-                    0.7, 0, 0.7, 120, 120, 135);
-        }
-
-        @Override
-        protected boolean onHitBlockBouncing(@NonNull Block hitBlock) {
-            return false;
-        }
-
-        @Override
-        protected boolean onHitEntityBouncing(@NonNull Damageable target, boolean isCrit) {
-            return false;
-        }
-
-        @Override
-        protected void onDestroy() {
-            MagmaCube magmaCube = CombatUtil.spawnEntity(MagmaCube.class, getLocation());
-            summonEntity = new JagerA2Entity(magmaCube, combatUser);
-            summonEntity.activate();
         }
     }
 }

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA3.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA3.java
@@ -36,9 +36,14 @@ public final class JagerA3 extends ActiveSkill {
     }
 
     @Override
+    public int getPriority() {
+        return 2;
+    }
+
+    @Override
     @NonNull
     public ActionKey @NonNull [] getDefaultActionKeys() {
-        return new ActionKey[]{ActionKey.SLOT_3};
+        return new ActionKey[]{ActionKey.SLOT_3, ActionKey.LEFT_CLICK};
     }
 
     @Override
@@ -58,10 +63,12 @@ public final class JagerA3 extends ActiveSkill {
 
     @Override
     public void onUse(@NonNull ActionKey actionKey) {
-        combatUser.getWeapon().onCancelled();
-
         if (isDurationFinished()) {
+            if (actionKey != ActionKey.SLOT_3)
+                return;
+
             setDuration();
+            combatUser.getWeapon().onCancelled();
             combatUser.setGlobalCooldown((int) JagerA3Info.READY_DURATION);
             combatUser.getWeapon().setVisible(false);
 
@@ -93,6 +100,8 @@ public final class JagerA3 extends ActiveSkill {
                 }, 1, JagerA3Info.EXPLODE_DURATION));
             }, JagerA3Info.READY_DURATION));
         } else {
+            combatUser.getWeapon().setCooldown(2);
+
             Location loc = combatUser.getArmLocation(true);
             new JagerA3Projectile().shoot(loc);
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA3.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerA3.java
@@ -52,8 +52,8 @@ public final class JagerA3 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && !combatUser.getSkill(JagerA1Info.getInstance()).getConfirmModule().isChecking();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && !combatUser.getSkill(JagerA1Info.getInstance()).getConfirmModule().isChecking();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerUlt.java
@@ -21,7 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
-import org.bukkit.entity.MagmaCube;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
@@ -121,7 +121,7 @@ public final class JagerUlt extends UltimateSkill {
 
         @Override
         protected void onDestroy() {
-            MagmaCube magmaCube = CombatUtil.spawnEntity(MagmaCube.class, getLocation());
+            ArmorStand magmaCube = CombatUtil.spawnEntity(ArmorStand.class, getLocation());
             summonEntity = new JagerUltEntity(magmaCube, combatUser);
             summonEntity.activate();
         }
@@ -131,7 +131,7 @@ public final class JagerUlt extends UltimateSkill {
      * 눈폭풍 발생기 클래스.
      */
     @Getter
-    public final class JagerUltEntity extends SummonEntity<MagmaCube> implements HasReadyTime, Damageable, Attacker {
+    public final class JagerUltEntity extends SummonEntity<ArmorStand> implements HasReadyTime, Damageable, Attacker {
         /** 넉백 모듈 */
         @NonNull
         private final KnockbackModule knockbackModule;
@@ -148,12 +148,12 @@ public final class JagerUlt extends UltimateSkill {
         @NonNull
         private final ReadyTimeModule readyTimeModule;
 
-        private JagerUltEntity(@NonNull MagmaCube entity, @NonNull CombatUser owner) {
+        private JagerUltEntity(@NonNull ArmorStand entity, @NonNull CombatUser owner) {
             super(
                     entity,
                     owner.getName() + "의 눈폭풍 발생기",
                     owner,
-                    true,
+                    true, true,
                     new FixedPitchHitbox(entity.getLocation(), 0.7, 0.2, 0.7, 0, 0.1, 0)
             );
             knockbackModule = new KnockbackModule(this, 2);
@@ -167,10 +167,14 @@ public final class JagerUlt extends UltimateSkill {
 
         private void onInit() {
             entity.setAI(false);
-            entity.setSize(1);
+            entity.setGravity(false);
             entity.setSilent(true);
             entity.setInvulnerable(true);
-            entity.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 0, false, false), true);
+            entity.setMarker(true);
+            entity.setSmall(true);
+            entity.setVisible(false);
+            entity.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 0, false,
+                    false), true);
             damageModule.setMaxHealth(JagerUltInfo.HEALTH);
             damageModule.setHealth(JagerUltInfo.HEALTH);
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerUlt.java
@@ -50,8 +50,8 @@ public final class JagerUlt extends UltimateSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && !combatUser.getSkill(JagerA1Info.getInstance()).getConfirmModule().isChecking() &&
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && !combatUser.getSkill(JagerA1Info.getInstance()).getConfirmModule().isChecking() &&
                 combatUser.getSkill(JagerA3Info.getInstance()).isDurationFinished();
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponInfo.java
@@ -40,8 +40,6 @@ public final class JagerWeaponInfo extends WeaponInfo<JagerWeaponL> {
      */
     @UtilityClass
     public static class SCOPE {
-        /** 쿨타임 (tick) */
-        public static final long COOLDOWN = (long) (0.25 * 20);
         /** 피해량 */
         public static final int DAMAGE = 240;
         /** 피해량 감소 시작 거리 (단위: 블록) */

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
@@ -55,8 +55,9 @@ public final class JagerWeaponL extends AbstractWeapon implements Reloadable, Sw
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && !combatUser.getSkill(JagerA1Info.getInstance()).getConfirmModule().isChecking() &&
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return (actionKey == ActionKey.DROP ? combatUser.isGlobalCooldownFinished() : super.canUse(actionKey)) &&
+                !combatUser.getSkill(JagerA1Info.getInstance()).getConfirmModule().isChecking() &&
                 combatUser.getSkill(JagerA3Info.getInstance()).isDurationFinished();
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponL.java
@@ -87,7 +87,9 @@ public final class JagerWeaponL extends AbstractWeapon implements Reloadable, Sw
                 break;
             }
             case RIGHT_CLICK: {
+                setCooldown(2);
                 onCancelled();
+
                 aimModule.toggleAim();
                 swapModule.swap();
 
@@ -210,6 +212,12 @@ public final class JagerWeaponL extends AbstractWeapon implements Reloadable, Sw
         protected void onTrailInterval() {
             Location loc = LocationUtil.getLocationFromOffset(getLocation(), 0.2, -0.2, 0);
             ParticleUtil.playRGB(ParticleUtil.ColoredParticle.REDSTONE, loc, 1, 0, 0, 0, 137, 185, 240);
+        }
+
+        @Override
+        protected void onHit() {
+            ParticleUtil.playRGB(ParticleUtil.ColoredParticle.REDSTONE, getLocation(), 10, 0.25, 0.25, 0.25,
+                    137, 185, 240);
         }
 
         @Override

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponR.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponR.java
@@ -72,6 +72,7 @@ public final class JagerWeaponR extends AbstractWeapon implements Reloadable {
                 break;
             }
             case RIGHT_CLICK: {
+                setCooldown(2);
                 onCancelled();
 
                 break;

--- a/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponR.java
+++ b/src/main/java/com/dace/dmgr/combat/character/jager/action/JagerWeaponR.java
@@ -14,6 +14,8 @@ import com.dace.dmgr.util.LocationUtil;
 import com.dace.dmgr.util.NamedSound;
 import com.dace.dmgr.util.ParticleUtil;
 import com.dace.dmgr.util.SoundUtil;
+import com.dace.dmgr.util.task.DelayTask;
+import com.dace.dmgr.util.task.TaskUtil;
 import lombok.Getter;
 import lombok.NonNull;
 import org.bukkit.Location;
@@ -41,12 +43,12 @@ public final class JagerWeaponR extends AbstractWeapon implements Reloadable {
 
     @Override
     public long getDefaultCooldown() {
-        return JagerWeaponInfo.SCOPE.COOLDOWN;
+        return JagerWeaponInfo.COOLDOWN;
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && mainWeapon.canUse();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return actionKey == ActionKey.DROP ? combatUser.isGlobalCooldownFinished() : super.canUse(actionKey);
     }
 
     @Override
@@ -105,7 +107,7 @@ public final class JagerWeaponR extends AbstractWeapon implements Reloadable {
             return;
 
         onCancelled();
-        mainWeapon.getReloadModule().reload();
+        TaskUtil.addTask(taskRunner, new DelayTask(() -> mainWeapon.getReloadModule().reload(), getDefaultCooldown()));
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceP1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceP1.java
@@ -33,8 +33,8 @@ public final class NeaceP1 extends AbstractSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && CooldownUtil.getCooldown(combatUser, COOLDOWN_ID) == 0;
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && CooldownUtil.getCooldown(combatUser, COOLDOWN_ID) == 0;
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceUlt.java
@@ -44,8 +44,8 @@ public final class NeaceUlt extends UltimateSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && combatUser.getSkill(NeaceA3Info.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && combatUser.getSkill(NeaceA3Info.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceWeapon.java
@@ -137,6 +137,7 @@ public final class NeaceWeapon extends AbstractWeapon implements FullAuto {
         @Override
         protected void onFindEntity(@NonNull Damageable target) {
             NeaceWeapon.this.target = (Healable) target;
+            CooldownUtil.setCooldown(combatUser, BLOCK_RESET_DELAY_COOLDOWN_ID, NeaceWeaponInfo.HEAL.BLOCK_RESET_DELAY);
 
             TaskUtil.addTask(NeaceWeapon.this, new IntervalTask(i -> target.canBeTargeted() && !target.isDisposed() &&
                     CooldownUtil.getCooldown(combatUser, TARGET_RESET_DELAY_COOLDOWN_ID) > 0 &&

--- a/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/neace/action/NeaceWeapon.java
@@ -55,8 +55,8 @@ public final class NeaceWeapon extends AbstractWeapon implements FullAuto {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && combatUser.getSkill(NeaceUltInfo.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && combatUser.getSkill(NeaceUltInfo.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerA2.java
@@ -51,8 +51,8 @@ public final class QuakerA2 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && combatUser.getSkill(QuakerA1Info.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && combatUser.getSkill(QuakerA1Info.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerA3.java
+++ b/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerA3.java
@@ -46,8 +46,8 @@ public final class QuakerA3 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && combatUser.getSkill(QuakerA1Info.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && combatUser.getSkill(QuakerA1Info.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerUlt.java
@@ -44,13 +44,13 @@ public final class QuakerUlt extends UltimateSkill {
     }
 
     @Override
-    public boolean canUse() {
+    public boolean canUse(@NonNull ActionKey actionKey) {
         if (combatUser.getSkill(QuakerA1Info.getInstance()).isDurationFinished()) {
             combatUser.getUser().sendAlert(QuakerA1Info.getInstance() + " 를 활성화한 상태에서만 사용할 수 있습니다.");
             return false;
         }
 
-        return super.canUse() && isDurationFinished();
+        return super.canUse(actionKey) && isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerWeapon.java
@@ -42,8 +42,8 @@ public final class QuakerWeapon extends AbstractWeapon {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && combatUser.getSkill(QuakerA1Info.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && combatUser.getSkill(QuakerA1Info.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/character/quaker/action/QuakerWeaponInfo.java
@@ -8,7 +8,7 @@ public final class QuakerWeaponInfo extends WeaponInfo<QuakerWeapon> {
     /** 쿨타임 (tick) */
     public static final long COOLDOWN = (long) (1.1 * 20);
     /** 전역 쿨타임 (tick) */
-    public static final int GLOBAL_COOLDOWN = (int) (0.4 * 20);
+    public static final int GLOBAL_COOLDOWN = (int) (0.3 * 20);
     /** 피해량 */
     public static final int DAMAGE = 320;
     /** 사거리 (단위: 블록) */

--- a/src/main/java/com/dace/dmgr/combat/character/silia/Silia.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/Silia.java
@@ -1,6 +1,7 @@
 package com.dace.dmgr.combat.character.silia;
 
 import com.dace.dmgr.combat.CombatEffectUtil;
+import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.info.ActiveSkillInfo;
 import com.dace.dmgr.combat.action.info.PassiveSkillInfo;
 import com.dace.dmgr.combat.action.skill.ActiveSkill;
@@ -162,7 +163,7 @@ public final class Silia extends Scuffler {
 
     @Override
     public boolean canFly(@NonNull CombatUser combatUser) {
-        return combatUser.getSkill(SiliaP1Info.getInstance()).canUse();
+        return combatUser.getSkill(SiliaP1Info.getInstance()).canUse(ActionKey.SPACE);
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA1.java
@@ -45,8 +45,8 @@ public final class SiliaA1 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && combatUser.getSkill(SiliaP2Info.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && combatUser.getSkill(SiliaP2Info.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA2.java
@@ -40,8 +40,8 @@ public final class SiliaA2 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && combatUser.getSkill(SiliaP2Info.getInstance()).isDurationFinished() &&
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && combatUser.getSkill(SiliaP2Info.getInstance()).isDurationFinished() &&
                 combatUser.getSkill(SiliaUltInfo.getInstance()).isDurationFinished();
     }
 

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA3.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaA3.java
@@ -46,8 +46,8 @@ public final class SiliaA3 extends ChargeableSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && combatUser.getSkill(SiliaUltInfo.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && combatUser.getSkill(SiliaUltInfo.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaP1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaP1.java
@@ -34,8 +34,8 @@ public final class SiliaP1 extends AbstractSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && combatUser.getSkill(SiliaP2Info.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && combatUser.getSkill(SiliaP2Info.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaP2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaP2.java
@@ -44,8 +44,8 @@ public final class SiliaP2 extends AbstractSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && canActivate();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && canActivate();
     }
 
     /**

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaUlt.java
@@ -36,8 +36,8 @@ public final class SiliaUlt extends UltimateSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/silia/action/SiliaWeapon.java
@@ -44,8 +44,8 @@ public final class SiliaWeapon extends AbstractWeapon {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && combatUser.getSkill(SiliaP2Info.getInstance()).isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && combatUser.getSkill(SiliaP2Info.getInstance()).isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA1.java
@@ -54,8 +54,8 @@ public final class VellionA1 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && !combatUser.getSkill(VellionA3Info.getInstance()).getConfirmModule().isChecking();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && !combatUser.getSkill(VellionA3Info.getInstance()).getConfirmModule().isChecking();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA1.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA1.java
@@ -190,7 +190,7 @@ public final class VellionA1 extends ActiveSkill {
                     entity,
                     owner.getName() + "의 마력 응집체",
                     owner,
-                    true,
+                    false, true,
                     new FixedPitchHitbox(entity.getLocation(), 1, 1, 1, 0, 0.5, 0)
             );
 

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA2.java
@@ -59,8 +59,8 @@ public final class VellionA2 extends ActiveSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && !combatUser.getSkill(VellionA3Info.getInstance()).getConfirmModule().isChecking();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && !combatUser.getSkill(VellionA3Info.getInstance()).getConfirmModule().isChecking();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA2.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA2.java
@@ -135,6 +135,7 @@ public final class VellionA2 extends ActiveSkill {
             setDuration();
             combatUser.setGlobalCooldown((int) VellionA2Info.READY_DURATION);
             combatUser.getMoveModule().getSpeedStatus().addModifier(MODIFIER_ID, -VellionA2Info.READY_SLOW);
+            CooldownUtil.setCooldown(combatUser, BLOCK_RESET_DELAY_COOLDOWN_ID, VellionA2Info.BLOCK_RESET_DELAY);
 
             SoundUtil.playNamedSound(NamedSound.COMBAT_VELLION_A2_USE, combatUser.getEntity().getLocation());
 

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA3.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionA3.java
@@ -58,8 +58,8 @@ public final class VellionA3 extends ActiveSkill implements Confirmable {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionUlt.java
@@ -46,8 +46,8 @@ public final class VellionUlt extends UltimateSkill {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && isDurationFinished() && !combatUser.getSkill(VellionA3Info.getInstance()).getConfirmModule().isChecking();
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && isDurationFinished() && !combatUser.getSkill(VellionA3Info.getInstance()).getConfirmModule().isChecking();
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/character/vellion/action/VellionWeapon.java
@@ -33,8 +33,8 @@ public final class VellionWeapon extends AbstractWeapon {
     }
 
     @Override
-    public boolean canUse() {
-        return super.canUse() && !combatUser.getSkill(VellionA3Info.getInstance()).getConfirmModule().isChecking() &&
+    public boolean canUse(@NonNull ActionKey actionKey) {
+        return super.canUse(actionKey) && !combatUser.getSkill(VellionA3Info.getInstance()).getConfirmModule().isChecking() &&
                 combatUser.getSkill(VellionUltInfo.getInstance()).isDurationFinished();
     }
 

--- a/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
@@ -1314,7 +1314,7 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
             if (statusEffectModule.hasStatusEffectType(StatusEffectType.STUN))
                 return;
 
-            if (action instanceof MeleeAttackAction && action.canUse()) {
+            if (action instanceof MeleeAttackAction && action.canUse(actionKey)) {
                 action.onUse(actionKey);
                 return;
             }
@@ -1339,7 +1339,7 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
     private void handleUseWeapon(@NonNull ActionKey actionKey, @NonNull Weapon weapon) {
         if (weapon instanceof FullAuto && (((FullAuto) weapon).getFullAutoModule().getFullAutoKey() == actionKey))
             handleUseFullAutoWeapon(actionKey, weapon);
-        else if (weapon.canUse())
+        else if (weapon.canUse(actionKey))
             weapon.onUse(actionKey);
     }
 
@@ -1368,7 +1368,7 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
                     if (CooldownUtil.getCooldown(weapon, Cooldown.WEAPON_FULLAUTO.id) == 0)
                         return false;
 
-                    if (weapon.canUse() && !isDead() && isGlobalCooldownFinished() && ((FullAuto) weapon).getFullAutoModule().isFireTick(i)) {
+                    if (weapon.canUse(actionKey) && !isDead() && isGlobalCooldownFinished() && ((FullAuto) weapon).getFullAutoModule().isFireTick(i)) {
                         j++;
                         weapon.onUse(actionKey);
                     }
@@ -1387,7 +1387,7 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
      * @param skill     스킬
      */
     private void handleUseSkill(@NonNull ActionKey actionKey, @NonNull Skill skill) {
-        if (!skill.canUse() || statusEffectModule.hasStatusEffectType(StatusEffectType.SILENCE))
+        if (!skill.canUse(actionKey) || statusEffectModule.hasStatusEffectType(StatusEffectType.SILENCE))
             return;
 
         skill.onUse(actionKey);

--- a/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
@@ -243,8 +243,10 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
         super.activate();
 
         for (CombatEntity combatEntity : game == null ? CombatEntity.getAllExcluded() : game.getAllCombatEntities()) {
-            if (combatEntity instanceof Damageable && combatEntity.isEnemy(this))
+            if (combatEntity instanceof Damageable && combatEntity.isEnemy(this)) {
                 HologramUtil.setHologramVisibility(DamageModule.HEALTH_HOLOGRAM_ID + combatEntity, false, entity);
+                HologramUtil.setHologramVisibility(SummonEntity.NAMETAG_HOLOGRAM_ID + combatEntity, false, entity);
+            }
 
             if (combatEntity instanceof CombatUser)
                 HologramUtil.setHologramVisibility(combatEntity.getEntity().getName(), false, entity);

--- a/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/CombatUser.java
@@ -950,7 +950,7 @@ public final class CombatUser extends AbstractCombatEntity<Player> implements He
         Location deadLocation = (gameUser == null ? FreeCombat.getWaitLocation() : gameUser.getRespawnLocation()).add(0, 2, 0);
         user.teleport(deadLocation);
 
-        CooldownUtil.setCooldown(this, Cooldown.RESPAWN.id, Cooldown.RESPAWN.duration);
+        CooldownUtil.setCooldown(this, Cooldown.RESPAWN.id, gameUser == null ? 20 : Cooldown.RESPAWN.duration);
         entity.setGameMode(GameMode.SPECTATOR);
         entity.setVelocity(new Vector());
 

--- a/src/main/java/com/dace/dmgr/combat/entity/module/DamageModule.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/module/DamageModule.java
@@ -11,7 +11,9 @@ import com.dace.dmgr.combat.interaction.Projectile;
 import com.dace.dmgr.util.CooldownUtil;
 import com.dace.dmgr.util.HologramUtil;
 import com.dace.dmgr.util.StringFormUtil;
+import com.dace.dmgr.util.task.DelayTask;
 import com.dace.dmgr.util.task.IntervalTask;
+import com.dace.dmgr.util.task.TaskUtil;
 import lombok.Getter;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
@@ -106,7 +108,7 @@ public class DamageModule {
         setHealth(getMaxHealth());
 
         if (isShowHealthBar)
-            addHealthHologram();
+            TaskUtil.addTask(combatEntity, new DelayTask(this::addHealthHologram, 5));
     }
 
     /**

--- a/src/main/java/com/dace/dmgr/combat/entity/temporary/Barrier.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/temporary/Barrier.java
@@ -47,7 +47,7 @@ public abstract class Barrier<T extends Entity> extends SummonEntity<T> implemen
      * @throws IllegalStateException 해당 {@code entity}의 CombatEntity가 이미 존재하면 발생
      */
     protected Barrier(@NonNull T entity, @NonNull String name, @NonNull CombatUser owner, int score, int maxHealth, @NonNull Hitbox @NonNull ... hitboxes) {
-        super(entity, name, owner, false, hitboxes);
+        super(entity, name, owner, false, false, hitboxes);
 
         knockbackModule = new KnockbackModule(this, 2);
         statusEffectModule = new StatusEffectModule(this, 2);

--- a/src/main/java/com/dace/dmgr/combat/entity/temporary/SummonEntity.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/temporary/SummonEntity.java
@@ -4,11 +4,15 @@ import com.comphenix.packetwrapper.WrapperPlayServerEntityDestroy;
 import com.dace.dmgr.combat.entity.CombatUser;
 import com.dace.dmgr.combat.interaction.Hitbox;
 import com.dace.dmgr.user.User;
+import com.dace.dmgr.util.HologramUtil;
+import com.dace.dmgr.util.task.DelayTask;
+import com.dace.dmgr.util.task.TaskUtil;
 import lombok.Getter;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.MustBeInvokedByOverriders;
 
 /**
  * 전투에서 일시적으로 사용하는 엔티티 중 플레이어가 소환할 수 있는 엔티티 클래스.
@@ -17,6 +21,8 @@ import org.bukkit.entity.Player;
  */
 @Getter
 public abstract class SummonEntity<T extends Entity> extends TemporaryEntity<T> {
+    /** 이름표 홀로그램 ID */
+    public static final String NAMETAG_HOLOGRAM_ID = "NameTag";
     /** 엔티티를 소환한 플레이어 */
     @NonNull
     protected final CombatUser owner;
@@ -27,23 +33,47 @@ public abstract class SummonEntity<T extends Entity> extends TemporaryEntity<T> 
      * @param entity         대상 엔티티
      * @param name           이름
      * @param owner          엔티티를 소환한 플레이어
+     * @param showNameTag    아군에게 이름표 표시 여부
      * @param hideForEnemies 엔티티를 적에게 보이지 할 지 여부
      * @param hitboxes       히트박스 목록
      * @throws IllegalStateException 해당 {@code entity}의 CombatEntity가 이미 존재하면 발생
      */
-    protected SummonEntity(@NonNull T entity, @NonNull String name, @NonNull CombatUser owner, boolean hideForEnemies,
+    protected SummonEntity(@NonNull T entity, @NonNull String name, @NonNull CombatUser owner, boolean showNameTag, boolean hideForEnemies,
                            @NonNull Hitbox @NonNull ... hitboxes) {
         super(entity, name, owner.getGame(), hitboxes);
 
         this.owner = owner;
+
+        if (showNameTag)
+            TaskUtil.addTask(this, new DelayTask(this::showNameTag, 5));
         if (hideForEnemies)
             hideForEnemies();
+    }
+
+    @Override
+    @MustBeInvokedByOverriders
+    public void dispose() {
+        super.dispose();
+        HologramUtil.removeHologram(NAMETAG_HOLOGRAM_ID + this);
     }
 
     @Override
     @NonNull
     public final String getTeamIdentifier() {
         return owner.getTeamIdentifier();
+    }
+
+    /**
+     * 모든 아군에게 엔티티의 이름표를 표시한다.
+     */
+    private void showNameTag() {
+        HologramUtil.addHologram(NAMETAG_HOLOGRAM_ID + this, entity, 0, entity.getHeight() + 0.7, 0, "§n" + name);
+
+        Bukkit.getOnlinePlayers().forEach((Player target) -> {
+            CombatUser targetCombatUser = CombatUser.fromUser(User.fromPlayer(target));
+            if (targetCombatUser != null && getOwner().isEnemy(targetCombatUser))
+                HologramUtil.setHologramVisibility(NAMETAG_HOLOGRAM_ID + this, false, target);
+        });
     }
 
     /**

--- a/src/main/java/com/dace/dmgr/combat/interaction/Target.java
+++ b/src/main/java/com/dace/dmgr/combat/interaction/Target.java
@@ -3,7 +3,6 @@ package com.dace.dmgr.combat.interaction;
 import com.dace.dmgr.combat.entity.CombatEntity;
 import com.dace.dmgr.combat.entity.CombatUser;
 import com.dace.dmgr.combat.entity.Damageable;
-import com.dace.dmgr.util.LocationUtil;
 import lombok.NonNull;
 import org.bukkit.block.Block;
 import org.jetbrains.annotations.Nullable;
@@ -46,9 +45,6 @@ public abstract class Target extends Hitscan {
 
     @Override
     protected final boolean onHitEntity(@NonNull Damageable target, boolean isCrit) {
-        if (!LocationUtil.canPass(((CombatUser) shooter).getEntity().getEyeLocation(), target.getCenterLocation()))
-            return true;
-
         currentTarget = target;
         onFindEntity(target);
 


### PR DESCRIPTION
- LocationConfirmModule(위치 확인 모듈) - 위치 보정 기능 추가
- 타겟팅 스킬의 범위 보정
- 자유 전투에서 사망 시 리스폰 시간 제거
- '퀘이커' 무기 - 전역 쿨타임 감소
- '예거' 액티브 3번 - 좌클릭으로 재사용 가능
- 무기 사용 직후 재장전 가능하게 수정 - Action.canUse 리팩토링
- 아군이 설치한 소환물의 이름표 표시