### PR TITLE
v0.13.1 완료

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dace.dmgr</groupId>
     <artifactId>DMGR</artifactId>
-    <version>0.13.0</version>
+    <version>0.13.1</version>
     <packaging>jar</packaging>
 
     <name>DMGR</name>

--- a/src/main/java/com/dace/dmgr/combat/combatant/arkace/ArkaceA1.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/arkace/ArkaceA1.java
@@ -63,7 +63,7 @@ public final class ArkaceA1 extends ActiveSkill {
 
     private final class ArkaceA1Projectile extends Projectile<Damageable> {
         private ArkaceA1Projectile() {
-            super(combatUser, ArkaceA1Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser));
+            super(ArkaceA1.this, ArkaceA1Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser));
         }
 
         @Override

--- a/src/main/java/com/dace/dmgr/combat/combatant/arkace/ArkaceUltInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/arkace/ArkaceUltInfo.java
@@ -7,6 +7,7 @@ import com.dace.dmgr.combat.action.info.ActionInfoLore;
 import com.dace.dmgr.combat.action.info.ActionInfoLore.Section.Format;
 import com.dace.dmgr.combat.action.info.UltimateSkillInfo;
 import com.dace.dmgr.effect.ParticleEffect;
+import com.dace.dmgr.effect.SoundEffect;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import org.bukkit.Color;
@@ -31,6 +32,18 @@ public final class ArkaceUltInfo extends UltimateSkillInfo<ArkaceUlt> {
                         .addValueInfo(TextIcon.DURATION, Format.TIME, DURATION.toSeconds())
                         .addActionKeyInfo("사용", ActionKey.SLOT_4)
                         .build()));
+    }
+
+    /**
+     * 효과음 정보.
+     */
+    @UtilityClass
+    public static final class SOUND {
+        /** 사격 */
+        public static final SoundEffect SHOOT = new SoundEffect(
+                SoundEffect.SoundInfo.builder("new.block.beacon.deactivate").volume(4).pitch(2).build(),
+                SoundEffect.SoundInfo.builder("random.energy").volume(4).pitch(1.6).build(),
+                SoundEffect.SoundInfo.builder("random.gun_reverb").volume(5).pitch(1.2).build());
     }
 
     /**

--- a/src/main/java/com/dace/dmgr/combat/combatant/arkace/ArkaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/arkace/ArkaceWeapon.java
@@ -75,7 +75,7 @@ public final class ArkaceWeapon extends AbstractWeapon implements Reloadable, Fu
                     addTask(new DelayTask(() -> CombatEffectUtil.SHELL_DROP_SOUND.play(loc), 8));
                 } else {
                     new ArkaceWeaponHitscan(true).shot();
-                    ArkaceWeaponInfo.SOUND.USE_ULT.play(loc);
+                    ArkaceUltInfo.SOUND.SHOOT.play(loc);
                 }
 
                 break;
@@ -170,7 +170,7 @@ public final class ArkaceWeapon extends AbstractWeapon implements Reloadable, Fu
                 if (!isUlt)
                     damage = CombatUtil.getDistantDamage(damage, getTravelDistance(), ArkaceWeaponInfo.DAMAGE_WEAKENING_DISTANCE);
 
-                target.getDamageModule().damage(combatUser, damage, DamageType.NORMAL, location, isCrit, isUlt);
+                target.getDamageModule().damage(combatUser, damage, DamageType.NORMAL, location, isCrit, !isUlt);
                 return false;
             });
         }

--- a/src/main/java/com/dace/dmgr/combat/combatant/arkace/ArkaceWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/arkace/ArkaceWeaponInfo.java
@@ -92,11 +92,6 @@ public final class ArkaceWeaponInfo extends WeaponInfo<ArkaceWeapon> {
         public static final SoundEffect USE = new SoundEffect(
                 SoundEffect.SoundInfo.builder("random.gun2.scarlight_1").volume(3).pitch(1).build(),
                 SoundEffect.SoundInfo.builder("random.gun_reverb").volume(5).pitch(1.2).build());
-        /** 사용 (궁극기) */
-        public static final SoundEffect USE_ULT = new SoundEffect(
-                SoundEffect.SoundInfo.builder("new.block.beacon.deactivate").volume(4).pitch(2).build(),
-                SoundEffect.SoundInfo.builder("random.energy").volume(4).pitch(1.6).build(),
-                SoundEffect.SoundInfo.builder("random.gun_reverb").volume(5).pitch(1.2).build());
         /** 재장전 */
         public static final TimedSoundEffect RELOAD = TimedSoundEffect.builder()
                 .add(3, SoundEffect.SoundInfo.builder(Sound.BLOCK_PISTON_CONTRACT).volume(0.6).pitch(1.6).build())

--- a/src/main/java/com/dace/dmgr/combat/combatant/ched/Ched.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/ched/Ched.java
@@ -1,7 +1,6 @@
 package com.dace.dmgr.combat.combatant.ched;
 
 import com.dace.dmgr.combat.CombatEffectUtil;
-import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.info.ActiveSkillInfo;
 import com.dace.dmgr.combat.action.info.PassiveSkillInfo;
 import com.dace.dmgr.combat.action.info.TraitInfo;
@@ -124,8 +123,19 @@ public final class Ched extends Marksman {
     }
 
     @Override
+    public boolean canSprint(@NonNull CombatUser combatUser) {
+        return combatUser.getSkill(ChedA3Info.getInstance()).isDurationFinished() && combatUser.getSkill(ChedUltInfo.getInstance()).isDurationFinished();
+    }
+
+    @Override
     public boolean canFly(@NonNull CombatUser combatUser) {
-        return combatUser.getSkill(ChedA2Info.getInstance()).canUse(ActionKey.SPACE);
+        ChedA2 skill2 = combatUser.getSkill(ChedA2Info.getInstance());
+        return skill2.canUse(skill2.getDefaultActionKeys()[1]);
+    }
+
+    @Override
+    public boolean canJump(@NonNull CombatUser combatUser) {
+        return canSprint(combatUser);
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedA1.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedA1.java
@@ -119,7 +119,7 @@ public final class ChedA1 extends StackableSkill {
 
     private final class ChedA1Projectile extends Projectile<Damageable> {
         private ChedA1Projectile() {
-            super(combatUser, ChedA1Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser));
+            super(ChedA1.this, ChedA1Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser));
         }
 
         @Override

--- a/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedA3.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedA3.java
@@ -135,7 +135,7 @@ public final class ChedA3 extends ActiveSkill implements HasBonusScore {
 
     private final class ChedA3Projectile extends Projectile<Damageable> {
         private ChedA3Projectile() {
-            super(combatUser, ChedA3Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser).and(Damageable::isCreature),
+            super(ChedA3.this, ChedA3Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser).and(Damageable::isCreature),
                     Option.builder().size(ChedA3Info.SIZE).build());
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedP1.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedP1.java
@@ -87,7 +87,12 @@ public final class ChedP1 extends AbstractSkill {
         ChedWeapon weapon = (ChedWeapon) combatUser.getWeapon();
         weapon.setVisible(false);
 
-        float yaw = combatUser.getEntity().getEyeLocation().getYaw();
+        Location location = combatUser.getEntity().getEyeLocation();
+        double distance = location.distance(combatUser.getEntity().getTargetBlock(null, 1).getLocation());
+        if (distance < 1)
+            combatUser.getMoveModule().teleport(LocationUtil.getLocationFromOffset(combatUser.getLocation(), 0, 0, -1 + distance));
+
+        float yaw = location.getYaw();
 
         addActionTask(new IntervalTask(i -> {
             if (combatUser.getMoveModule().isKnockbacked())

--- a/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedUlt.java
@@ -156,7 +156,7 @@ public final class ChedUlt extends UltimateSkill implements Summonable<ChedUlt.C
 
     private final class ChedUltProjectile extends Projectile<Damageable> {
         private ChedUltProjectile() {
-            super(combatUser, ChedUltInfo.VELOCITY,
+            super(ChedUlt.this, ChedUltInfo.VELOCITY,
                     CombatUtil.EntityCondition.enemy(combatUser).and(combatEntity ->
                             combatEntity instanceof CombatUser || combatEntity instanceof Dummy),
                     Option.builder().size(ChedUltInfo.SIZE).build());

--- a/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/ched/ChedWeapon.java
@@ -88,7 +88,7 @@ public final class ChedWeapon extends AbstractWeapon {
         private final double power;
 
         private ChedWeaponProjectile(double power) {
-            super(combatUser, (int) (power * ChedWeaponInfo.MAX_VELOCITY), CombatUtil.EntityCondition.enemy(combatUser));
+            super(ChedWeapon.this, (int) (power * ChedWeaponInfo.MAX_VELOCITY), CombatUtil.EntityCondition.enemy(combatUser));
             this.power = power;
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/inferno/InfernoWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/inferno/InfernoWeapon.java
@@ -145,7 +145,7 @@ public final class InfernoWeapon extends AbstractWeapon implements Reloadable, F
 
     private final class InfernoWeaponRProjectile extends Projectile<Damageable> {
         private InfernoWeaponRProjectile() {
-            super(combatUser, InfernoWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(InfernoWeapon.this, InfernoWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(InfernoWeaponInfo.SIZE).maxDistance(InfernoWeaponInfo.DISTANCE).build());
         }
 
@@ -187,7 +187,7 @@ public final class InfernoWeapon extends AbstractWeapon implements Reloadable, F
 
     private final class InfernoWeaponLProjectile extends Projectile<Damageable> {
         private InfernoWeaponLProjectile() {
-            super(combatUser, InfernoWeaponInfo.FIREBALL.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(InfernoWeapon.this, InfernoWeaponInfo.FIREBALL.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(InfernoWeaponInfo.FIREBALL.SIZE).maxDistance(InfernoWeaponInfo.FIREBALL.DISTANCE).build());
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerA2.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerA2.java
@@ -82,7 +82,7 @@ public final class JagerA2 extends ActiveSkill implements Summonable<JagerA2.Jag
 
     private final class JagerA2Projectile extends BouncingProjectile<Damageable> {
         private JagerA2Projectile() {
-            super(combatUser, JagerA2Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(JagerA2.this, JagerA2Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Projectile.Option.builder().duration(Timespan.ofSeconds(5)).build(),
                     Option.builder().bounceVelocityMultiplier(0.35).build());
         }

--- a/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerA3.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerA3.java
@@ -158,7 +158,7 @@ public final class JagerA3 extends ActiveSkill {
 
     private final class JagerA3Projectile extends BouncingProjectile<Damageable> {
         private JagerA3Projectile() {
-            super(combatUser, JagerA3Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(JagerA3.this, JagerA3Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Projectile.Option.builder().duration(Timestamp.now().until(explodeTimestamp)).build(),
                     Option.builder().bounceVelocityMultiplier(0.35).build());
         }

--- a/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerUlt.java
@@ -89,7 +89,7 @@ public final class JagerUlt extends UltimateSkill implements Summonable<JagerUlt
 
     private final class JagerUltProjectile extends BouncingProjectile<Damageable> {
         private JagerUltProjectile() {
-            super(combatUser, JagerUltInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(JagerUlt.this, JagerUltInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Projectile.Option.builder().duration(Timespan.ofSeconds(5)).build(),
                     Option.builder().bounceVelocityMultiplier(0.35).build());
         }

--- a/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerWeaponL.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerWeaponL.java
@@ -170,7 +170,7 @@ public final class JagerWeaponL extends AbstractWeapon implements Reloadable, Sw
 
     private final class JagerWeaponLProjectile extends Projectile<Damageable> {
         private JagerWeaponLProjectile() {
-            super(combatUser, JagerWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(JagerWeaponL.this, JagerWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().maxDistance(JagerWeaponInfo.DISTANCE).build());
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/magritta/MagrittaA1.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/magritta/MagrittaA1.java
@@ -82,7 +82,7 @@ public final class MagrittaA1 extends ActiveSkill {
 
     private final class MagrittaA1Projectile extends Projectile<Damageable> {
         private MagrittaA1Projectile() {
-            super(combatUser, MagrittaA1Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser));
+            super(MagrittaA1.this, MagrittaA1Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser));
         }
 
         @Override

--- a/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceWeapon.java
@@ -133,7 +133,7 @@ public final class NeaceWeapon extends AbstractWeapon implements FullAuto {
 
     private final class NeaceWeaponLProjectile extends Projectile<Damageable> {
         private NeaceWeaponLProjectile() {
-            super(combatUser, NeaceWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(NeaceWeapon.this, NeaceWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(NeaceWeaponInfo.SIZE).maxDistance(NeaceWeaponInfo.DISTANCE).build());
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasA1.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasA1.java
@@ -103,7 +103,7 @@ public final class PalasA1 extends ActiveSkill implements HasBonusScore {
 
     private final class PalasA1Projectile extends Projectile<Damageable> {
         private PalasA1Projectile() {
-            super(combatUser, PalasA1Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser));
+            super(PalasA1.this, PalasA1Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser));
         }
 
         @Override

--- a/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasA2.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasA2.java
@@ -6,10 +6,7 @@ import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.skill.ActiveSkill;
 import com.dace.dmgr.combat.action.skill.Targeted;
 import com.dace.dmgr.combat.action.skill.module.TargetModule;
-import com.dace.dmgr.combat.entity.CombatEntity;
-import com.dace.dmgr.combat.entity.CombatUser;
-import com.dace.dmgr.combat.entity.Damageable;
-import com.dace.dmgr.combat.entity.Healable;
+import com.dace.dmgr.combat.entity.*;
 import com.dace.dmgr.combat.entity.module.AbilityStatus;
 import com.dace.dmgr.combat.entity.module.statuseffect.StatusEffect;
 import com.dace.dmgr.util.LocationUtil;
@@ -20,8 +17,11 @@ import org.bukkit.inventory.MainHand;
 
 @Getter
 public final class PalasA2 extends ActiveSkill implements Targeted<Healable> {
-    /** 수정자 */
-    private static final AbilityStatus.Modifier MODIFIER = new AbilityStatus.Modifier(100);
+    /** 상태 효과 저항 수정자 */
+    private static final AbilityStatus.Modifier STATUS_EFFECT_RESISTANCE_MODIFIER = new AbilityStatus.Modifier(100);
+    /** 넉백 저항 수정자 */
+    private static final AbilityStatus.Modifier KNOCKBACK_RESISTANCE_MODIFIER = new AbilityStatus.Modifier(100);
+
     /** 타겟 모듈 */
     @NonNull
     private final TargetModule<Healable> targetModule;
@@ -93,7 +93,9 @@ public final class PalasA2 extends ActiveSkill implements Targeted<Healable> {
 
         @Override
         public void onStart(@NonNull Damageable combatEntity, @NonNull CombatEntity provider) {
-            combatEntity.getStatusEffectModule().getResistanceStatus().addModifier(MODIFIER);
+            combatEntity.getStatusEffectModule().getResistanceStatus().addModifier(STATUS_EFFECT_RESISTANCE_MODIFIER);
+            if (combatEntity instanceof Movable)
+                ((Movable) combatEntity).getMoveModule().getResistanceStatus().addModifier(KNOCKBACK_RESISTANCE_MODIFIER);
         }
 
         @Override
@@ -103,7 +105,9 @@ public final class PalasA2 extends ActiveSkill implements Targeted<Healable> {
 
         @Override
         public void onEnd(@NonNull Damageable combatEntity, @NonNull CombatEntity provider) {
-            combatEntity.getStatusEffectModule().getResistanceStatus().removeModifier(MODIFIER);
+            combatEntity.getStatusEffectModule().getResistanceStatus().removeModifier(STATUS_EFFECT_RESISTANCE_MODIFIER);
+            if (combatEntity instanceof Movable)
+                ((Movable) combatEntity).getMoveModule().getResistanceStatus().removeModifier(KNOCKBACK_RESISTANCE_MODIFIER);
         }
     }
 }

--- a/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasA3.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasA3.java
@@ -148,7 +148,7 @@ public final class PalasA3 extends ActiveSkill implements HasBonusScore {
 
     private final class PalasA3Projectile extends Projectile<Damageable> {
         private PalasA3Projectile() {
-            super(combatUser, PalasA3Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser).or(CombatUtil.EntityCondition.team(combatUser)
+            super(PalasA3.this, PalasA3Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser).or(CombatUtil.EntityCondition.team(combatUser)
                     .exclude(combatUser)));
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasA3.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasA3.java
@@ -198,6 +198,9 @@ public final class PalasA3 extends ActiveSkill implements HasBonusScore {
                         onHitEnemy(target);
                     else if (target instanceof Healable)
                         onHitTeamer((Healable) target);
+
+                    if (target != combatUser && target instanceof CombatUser)
+                        combatUser.addScore("생체 제어 수류탄", PalasA3Info.EFFECT_SCORE);
                 }
 
                 return !target.isEnemy(combatUser) || !(target instanceof Barrier);
@@ -226,10 +229,8 @@ public final class PalasA3 extends ActiveSkill implements HasBonusScore {
             private void onHitTeamer(@NonNull Healable target) {
                 target.getStatusEffectModule().apply(new PalasA3HealthIncrease(), combatUser, PalasA3Info.DURATION);
 
-                if (target instanceof CombatUser && target != combatUser) {
-                    combatUser.addScore("생체 제어 수류탄", PalasA3Info.EFFECT_SCORE);
+                if (target instanceof CombatUser && target != combatUser)
                     ((CombatUser) target).addKillHelper(combatUser, PalasA3.this, PalasA3Info.ASSIST_SCORE, PalasA3Info.DURATION);
-                }
             }
         }
     }

--- a/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasWeapon.java
@@ -1,5 +1,6 @@
 package com.dace.dmgr.combat.combatant.palas;
 
+import com.dace.dmgr.Timespan;
 import com.dace.dmgr.combat.CombatEffectUtil;
 import com.dace.dmgr.combat.CombatUtil;
 import com.dace.dmgr.combat.action.ActionKey;
@@ -159,6 +160,7 @@ public final class PalasWeapon extends AbstractWeapon implements Reloadable, Aim
      * 사용 후 쿨타임 작업을 수행한다.
      */
     private void action() {
+        setCooldown(Timespan.ZERO);
         setCooldown(PalasWeaponInfo.ACTION_COOLDOWN);
 
         reloadModule.cancel();

--- a/src/main/java/com/dace/dmgr/combat/combatant/quaker/QuakerA2.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/quaker/QuakerA2.java
@@ -191,7 +191,7 @@ public final class QuakerA2 extends ActiveSkill implements HasBonusScore {
         private final HashSet<Damageable> targets;
 
         private QuakerA2Projectile(@NonNull HashSet<Damageable> targets) {
-            super(combatUser, QuakerA2Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(QuakerA2.this, QuakerA2Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(QuakerA2Info.SIZE).maxDistance(QuakerA2Info.DISTANCE).build());
             this.targets = targets;
         }

--- a/src/main/java/com/dace/dmgr/combat/combatant/quaker/QuakerA3.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/quaker/QuakerA3.java
@@ -132,7 +132,7 @@ public final class QuakerA3 extends ActiveSkill {
         private final HashSet<Damageable> targets = new HashSet<>();
 
         private QuakerA3Projectile() {
-            super(combatUser, QuakerA3Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(QuakerA3.this, QuakerA3Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(QuakerA3Info.SIZE).maxDistance(QuakerA3Info.DISTANCE).build());
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/quaker/QuakerUlt.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/quaker/QuakerUlt.java
@@ -124,7 +124,7 @@ public final class QuakerUlt extends UltimateSkill implements HasBonusScore {
         private final HashSet<Damageable> targets;
 
         private QuakerUltProjectile(@NonNull HashSet<Damageable> targets) {
-            super(combatUser, QuakerUltInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(QuakerUlt.this, QuakerUltInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(QuakerUltInfo.SIZE).maxDistance(QuakerUltInfo.DISTANCE).build());
             this.targets = targets;
         }

--- a/src/main/java/com/dace/dmgr/combat/combatant/silia/SiliaA2.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/silia/SiliaA2.java
@@ -78,7 +78,7 @@ public final class SiliaA2 extends ActiveSkill {
 
     private final class SiliaA2Projectile extends Projectile<Damageable> {
         private SiliaA2Projectile() {
-            super(combatUser, SiliaA2Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(SiliaA2.this, SiliaA2Info.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(SiliaA2Info.SIZE).maxDistance(SiliaA2Info.DISTANCE).build());
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/silia/SiliaP2.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/silia/SiliaP2.java
@@ -59,6 +59,10 @@ public final class SiliaP2 extends AbstractSkill {
         combatUser.addYawAndPitch(0, 0);
         combatUser.getWeapon().setVisible(false);
 
+        double distance = combatUser.getEntity().getEyeLocation().distance(combatUser.getEntity().getTargetBlock(null, 1).getLocation());
+        if (distance < 1)
+            combatUser.getMoveModule().teleport(LocationUtil.getLocationFromOffset(combatUser.getLocation(), 0, 0, -1 + distance));
+
         addActionTask(new IntervalTask(i -> {
             if (combatUser.getMoveModule().isKnockbacked() || !canActivate())
                 return false;

--- a/src/main/java/com/dace/dmgr/combat/combatant/silia/SiliaWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/silia/SiliaWeapon.java
@@ -127,7 +127,7 @@ public final class SiliaWeapon extends AbstractWeapon {
 
     private final class SiliaWeaponProjectile extends Projectile<Damageable> {
         private SiliaWeaponProjectile() {
-            super(combatUser, SiliaWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(SiliaWeapon.this, SiliaWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(SiliaWeaponInfo.SIZE).maxDistance(SiliaWeaponInfo.DISTANCE).build());
         }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/vellion/VellionWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/vellion/VellionWeapon.java
@@ -42,7 +42,7 @@ public final class VellionWeapon extends AbstractWeapon {
 
     private final class VellionWeaponProjectile extends Projectile<Damageable> {
         private VellionWeaponProjectile() {
-            super(combatUser, VellionWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
+            super(VellionWeapon.this, VellionWeaponInfo.VELOCITY, CombatUtil.EntityCondition.enemy(combatUser),
                     Option.builder().size(VellionWeaponInfo.SIZE).maxDistance(VellionWeaponInfo.DISTANCE).build());
         }
 

--- a/src/main/java/com/dace/dmgr/combat/entity/module/StatusEffectModule.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/module/StatusEffectModule.java
@@ -258,7 +258,7 @@ public final class StatusEffectModule {
             statusEffect.onStart(combatEntity, provider);
 
             this.onTickTask = new IntervalTask(i -> {
-                if (this.expiration.isBefore(Timestamp.now()))
+                if (this.expiration.isBefore(Timestamp.now()) || provider.isRemoved())
                     return false;
 
                 statusEffect.onTick(combatEntity, provider, i);

--- a/src/main/java/com/dace/dmgr/combat/interaction/BouncingProjectile.java
+++ b/src/main/java/com/dace/dmgr/combat/interaction/BouncingProjectile.java
@@ -1,6 +1,7 @@
 package com.dace.dmgr.combat.interaction;
 
 import com.dace.dmgr.combat.CombatUtil;
+import com.dace.dmgr.combat.action.Action;
 import com.dace.dmgr.combat.entity.CombatEntity;
 import lombok.Builder;
 import lombok.NonNull;
@@ -9,6 +10,7 @@ import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * 튕기는 투사체. 투사체 중 벽이나 엔티티에 튕기는 투사체를 관리하는 클래스.
@@ -29,6 +31,34 @@ public abstract class BouncingProjectile<T extends CombatEntity> extends Project
      * <p>튕기는 투사체의 선택적 옵션은 {@link Option}을 통해 전달받는다.</p>
      *
      * @param shooter          발사자
+     * @param action           발사자가 사용한 동작
+     * @param speed            투사체의 속력. (단위: 블록/s). 0 이상의 값
+     * @param entityCondition  대상 엔티티를 찾는 조건
+     * @param projectileOption 투사체의 선택적 옵션
+     * @param option           튕기는 투사체의 선택적 옵션
+     * @throws IllegalArgumentException 인자값이 유효하지 않으면 발생
+     * @see Projectile.Option
+     * @see Option
+     */
+    BouncingProjectile(@NonNull CombatEntity shooter, @Nullable Action action, int speed, @NonNull CombatUtil.EntityCondition<T> entityCondition,
+                       @NonNull Projectile.Option projectileOption, @NonNull Option option) {
+        super(shooter, action, speed, entityCondition, projectileOption);
+
+        this.bounceVelocityMultiplier = option.bounceVelocityMultiplier;
+        Validate.isTrue(bounceVelocityMultiplier <= 1, "bounceVelocityMultiplier <= 1 (%f)", bounceVelocityMultiplier);
+
+        this.bouncingCount = option.bouncingCount;
+        Validate.isTrue(bouncingCount >= 1, "bouncingCount >= 1 (%d)", bouncingCount);
+    }
+
+    /**
+     * 튕기는 투사체 인스턴스를 생성한다.
+     *
+     * <p>투사체의 선택적 옵션은 {@link Projectile.Option}을 통해 전달받는다.</p>
+     *
+     * <p>튕기는 투사체의 선택적 옵션은 {@link Option}을 통해 전달받는다.</p>
+     *
+     * @param shooter          발사자
      * @param speed            투사체의 속력. (단위: 블록/s). 0 이상의 값
      * @param entityCondition  대상 엔티티를 찾는 조건
      * @param projectileOption 투사체의 선택적 옵션
@@ -39,13 +69,28 @@ public abstract class BouncingProjectile<T extends CombatEntity> extends Project
      */
     protected BouncingProjectile(@NonNull CombatEntity shooter, int speed, @NonNull CombatUtil.EntityCondition<T> entityCondition,
                                  @NonNull Projectile.Option projectileOption, @NonNull Option option) {
-        super(shooter, speed, entityCondition, projectileOption);
+        this(shooter, null, speed, entityCondition, projectileOption, option);
+    }
 
-        this.bounceVelocityMultiplier = option.bounceVelocityMultiplier;
-        Validate.isTrue(bounceVelocityMultiplier <= 1, "bounceVelocityMultiplier <= 1 (%f)", bounceVelocityMultiplier);
-
-        this.bouncingCount = option.bouncingCount;
-        Validate.isTrue(bouncingCount >= 1, "bouncingCount >= 1 (%d)", bouncingCount);
+    /**
+     * 튕기는 투사체 인스턴스를 생성한다.
+     *
+     * <p>투사체의 선택적 옵션은 {@link Projectile.Option}을 통해 전달받는다.</p>
+     *
+     * <p>튕기는 투사체의 선택적 옵션은 {@link Option}을 통해 전달받는다.</p>
+     *
+     * @param action           발사자가 사용한 동작
+     * @param speed            투사체의 속력. (단위: 블록/s). 0 이상의 값
+     * @param entityCondition  대상 엔티티를 찾는 조건
+     * @param projectileOption 투사체의 선택적 옵션
+     * @param option           튕기는 투사체의 선택적 옵션
+     * @throws IllegalArgumentException 인자값이 유효하지 않으면 발생
+     * @see Projectile.Option
+     * @see Option
+     */
+    protected BouncingProjectile(@NonNull Action action, int speed, @NonNull CombatUtil.EntityCondition<T> entityCondition,
+                                 @NonNull Projectile.Option projectileOption, @NonNull Option option) {
+        this(action.getCombatUser(), action, speed, entityCondition, projectileOption, option);
     }
 
     /**
@@ -62,7 +107,24 @@ public abstract class BouncingProjectile<T extends CombatEntity> extends Project
      */
     protected BouncingProjectile(@NonNull CombatEntity shooter, int speed, @NonNull CombatUtil.EntityCondition<T> entityCondition,
                                  @NonNull Projectile.Option projectileOption) {
-        this(shooter, speed, entityCondition, projectileOption, Option.builder().build());
+        this(shooter, null, speed, entityCondition, projectileOption, Option.builder().build());
+    }
+
+    /**
+     * 튕기는 투사체 인스턴스를 생성한다.
+     *
+     * <p>투사체의 선택적 옵션은 {@link Projectile.Option}을 통해 전달받는다.</p>
+     *
+     * @param action           발사자가 사용한 동작
+     * @param speed            투사체의 속력. (단위: 블록/s). 0 이상의 값
+     * @param entityCondition  대상 엔티티를 찾는 조건
+     * @param projectileOption 투사체의 선택적 옵션
+     * @throws IllegalArgumentException 인자값이 유효하지 않으면 발생
+     * @see Projectile.Option
+     */
+    protected BouncingProjectile(@NonNull Action action, int speed, @NonNull CombatUtil.EntityCondition<T> entityCondition,
+                                 @NonNull Projectile.Option projectileOption) {
+        this(action.getCombatUser(), action, speed, entityCondition, projectileOption, Option.builder().build());
     }
 
     /**
@@ -74,7 +136,19 @@ public abstract class BouncingProjectile<T extends CombatEntity> extends Project
      * @throws IllegalArgumentException 인자값이 유효하지 않으면 발생
      */
     protected BouncingProjectile(@NonNull CombatEntity shooter, int speed, @NonNull CombatUtil.EntityCondition<T> entityCondition) {
-        this(shooter, speed, entityCondition, Projectile.Option.builder().build(), Option.builder().build());
+        this(shooter, null, speed, entityCondition, Projectile.Option.builder().build(), Option.builder().build());
+    }
+
+    /**
+     * 튕기는 투사체 인스턴스를 생성한다.
+     *
+     * @param action          발사자가 사용한 동작
+     * @param speed           투사체의 속력. (단위: 블록/s). 0 이상의 값
+     * @param entityCondition 대상 엔티티를 찾는 조건
+     * @throws IllegalArgumentException 인자값이 유효하지 않으면 발생
+     */
+    protected BouncingProjectile(@NonNull Action action, int speed, @NonNull CombatUtil.EntityCondition<T> entityCondition) {
+        this(action.getCombatUser(), action, speed, entityCondition, Projectile.Option.builder().build(), Option.builder().build());
     }
 
     @Override


### PR DESCRIPTION
## 알려진 버그 수정
- 전투원 변경 및 퇴장 시 남은 투사체가 사라지도록 수정 (#213)
- 상태 효과 제공자가 제거되었을 때 상태 효과가 종료되도록 수정 (#213)
- '아케이스' 무기 - 궁극기를 충전할 수 없는 버그 수정
- '체드' 액티브 3번, 궁극기 - 사용 중 달리기 및 점프가 가능한 버그 수정
- '팔라스' 액티브 2번 - 해로운 효과 면역 상태에서 넉백을 무시하지 않는 버그 수정
- '팔라스' 액티브 3번 - 적에게 사용했을 때 점수가 지급되지 않는 버그 수정
- '실리아' 패시브 2번 및 '체드' 패시브 1번 - 벽타기가 정상적으로 사용되지 않는 버그 수정
- '팔라스' 무기 - 사격 후 무기의 쿨타임 상태가 정상적으로 보이지 않는 버그 수정