### PR TITLE
v0.15.1 완료

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dace.dmgr</groupId>
     <artifactId>DMGR</artifactId>
-    <version>0.15.0</version>
+    <version>0.15.1</version>
     <packaging>jar</packaging>
 
     <name>DMGR</name>

--- a/src/main/java/com/dace/dmgr/event/listener/OnEntityDamage.java
+++ b/src/main/java/com/dace/dmgr/event/listener/OnEntityDamage.java
@@ -33,6 +33,8 @@ public final class OnEntityDamage extends EventListener<EntityDamageEvent> {
                 case SUFFOCATION:
                 case DROWNING:
                 case CRAMMING:
+                case ENTITY_EXPLOSION:
+                case VOID:
                     event.setCancelled(true);
                     break;
                 default:


### PR DESCRIPTION
## 알려진 버그 수정
- 전투원을 선택하지 않았을 때 폭죽 폭발로 피해를 입을 수 있는 버그 수정