### PR TITLE
v0.15 밸런스 패치

### DIFF
--- a/src/main/java/com/dace/dmgr/combat/action/ActionBarStringUtil.java
+++ b/src/main/java/com/dace/dmgr/combat/action/ActionBarStringUtil.java
@@ -105,6 +105,29 @@ public final class ActionBarStringUtil {
     }
 
     /**
+     * 진행 막대를 반환한다.
+     *
+     * <p>기본적으로 흰색, 현재 값이 최대 값의 1/2 이하일 경우 노란색, 1/4 이하일 경우 빨간색으로 표시한다.</p>
+     *
+     * <p>Example:</p>
+     *
+     * <pre>[Test] <font color="yellow">■■■■</font><font color="black">■■■■■■</font> [40/100]</pre>
+     * <pre><code>
+     * ActionBarStringUtil.getProgressBar("[Test]", 40, 100);
+     * </code></pre>
+     *
+     * @param prefix  접두사
+     * @param current 현재 값
+     * @param max     최대 값
+     * @return 진행 막대 문자열
+     * @throws IllegalArgumentException 인자값이 유효하지 않으면 발생
+     */
+    @NonNull
+    public static String getProgressBar(@NonNull String prefix, int current, int max) {
+        return getProgressBar(prefix, current, max, 10, '■');
+    }
+
+    /**
      * 지정한 충전형 스킬의 상태 변수 진행 막대를 반환한다.
      *
      * <p>기본적으로 흰색, 상태 변수가 최대 값의 1/2 이하일 경우 노란색, 1/4 이하일 경우 빨간색으로 표시한다.</p>

--- a/src/main/java/com/dace/dmgr/combat/action/TextIcon.java
+++ b/src/main/java/com/dace/dmgr/combat/action/TextIcon.java
@@ -79,7 +79,9 @@ public enum TextIcon {
     /** 생명력 증가 */
     HEALTH_INCREASE('\u4DE1', ChatColor.GREEN),
     /** 생명력 감소 */
-    HEALTH_DECREASE('\u4DE2', ChatColor.RED);
+    HEALTH_DECREASE('\u4DE2', ChatColor.RED),
+    /** 미지정 */
+    UNDEFINED('⬜', ChatColor.WHITE);
 
     /** 아이콘 문자 */
     private final char icon;

--- a/src/main/java/com/dace/dmgr/combat/combatant/Combatant.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/Combatant.java
@@ -375,6 +375,16 @@ public abstract class Combatant {
     }
 
     /**
+     * 전투원이 강제로 밀쳐졌을 때 실행될 작업.
+     *
+     * @param victim 피격자
+     * @param speed  속력
+     */
+    public void onKnockbacked(@NonNull CombatUser victim, double speed) {
+        // 미사용
+    }
+
+    /**
      * 전투원이 다른 엔티티를 치유했을 때 실행될 작업.
      *
      * @param provider 제공자

--- a/src/main/java/com/dace/dmgr/combat/combatant/Guardian.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/Guardian.java
@@ -68,7 +68,7 @@ public abstract class Guardian extends Combatant {
      */
     private static final class RoleTrait1Info extends TraitInfo {
         /** 넉백 저항 */
-        private static final int KNOCKBACK_RESISTANCE = 20;
+        private static final int KNOCKBACK_RESISTANCE = 25;
         /** 방어력 */
         private static final int DEFENSE = 15;
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/Guardian.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/Guardian.java
@@ -68,7 +68,7 @@ public abstract class Guardian extends Combatant {
      */
     private static final class RoleTrait1Info extends TraitInfo {
         /** 넉백 저항 */
-        private static final int KNOCKBACK_RESISTANCE = 30;
+        private static final int KNOCKBACK_RESISTANCE = 20;
         /** 방어력 */
         private static final int DEFENSE = 15;
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/SelectCharInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/SelectCharInfo.java
@@ -34,7 +34,7 @@ public final class SelectCharInfo extends ChestGUI {
                         "§e✪ 난이도 §7:: §f{0}",
                         "§a{1} 생명력 §7:: §f{2}",
                         "§b{3} 이동속도 배수 §7:: §f{4}",
-                        "§6⬜ 히트박스 배수 §7:: §f{5}")
+                        "§6{5} 히트박스 배수 §7:: §f{6}")
                 .formatLore(
                         StringFormUtil.getProgressBar(combatant.getDifficulty(), 5, ChatColor.YELLOW, 5, '✰')
                                 .replace("§0", "§8"),
@@ -42,6 +42,7 @@ public final class SelectCharInfo extends ChestGUI {
                         combatant.getHealth(),
                         TextIcon.WALK_SPEED,
                         combatant.getSpeedMultiplier(),
+                        TextIcon.UNDEFINED,
                         combatant.getHitboxMultiplier())
                 .build()));
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/Vanguard.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/Vanguard.java
@@ -66,7 +66,7 @@ public abstract class Vanguard extends Combatant {
         /** 상태 효과 저항 */
         private static final int STATUS_EFFECT_RESISTANCE = 15;
         /** 넉백 저항 */
-        private static final int KNOCKBACK_RESISTANCE = 20;
+        private static final int KNOCKBACK_RESISTANCE = 25;
 
         private static final RoleTrait1Info instance = new RoleTrait1Info();
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/Vanguard.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/Vanguard.java
@@ -66,7 +66,7 @@ public abstract class Vanguard extends Combatant {
         /** 상태 효과 저항 */
         private static final int STATUS_EFFECT_RESISTANCE = 15;
         /** 넉백 저항 */
-        private static final int KNOCKBACK_RESISTANCE = 30;
+        private static final int KNOCKBACK_RESISTANCE = 20;
 
         private static final RoleTrait1Info instance = new RoleTrait1Info();
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/jager/JagerWeaponInfo.java
@@ -20,7 +20,7 @@ public final class JagerWeaponInfo extends WeaponInfo<JagerWeaponL> {
     /** 쿨타임 */
     public static final Timespan COOLDOWN = Timespan.ofSeconds(0.25);
     /** 피해량 */
-    public static final int DAMAGE = 70;
+    public static final int DAMAGE = 100;
     /** 사거리 (단위: 블록) */
     public static final int DISTANCE = 30;
     /** 투사체 속력 (단위: 블록/s) */

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/Metar.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/Metar.java
@@ -106,13 +106,21 @@ public final class Metar extends Guardian {
     public void onTick(@NonNull CombatUser combatUser, long i) {
         super.onTick(combatUser, i);
 
-        if (combatUser.getEntity().isSneaking())
-            combatUser.getActionManager().useAction(ActionKey.PERIODIC_1);
+        MetarP1 skillp1 = combatUser.getActionManager().getSkill(MetarP1Info.getInstance());
+        skillp1.addValue(MetarP1Info.RECOVER_PER_SECOND / 20.0);
+
+        combatUser.getActionManager().useAction(ActionKey.PERIODIC_1);
     }
 
     @Override
     public void onFootstep(@NonNull CombatUser combatUser, double volume) {
         FOOTSTEP_SOUND.play(combatUser.getLocation(), volume);
+    }
+
+    @Override
+    public void onKnockbacked(@NonNull CombatUser victim, double speed) {
+        MetarP1 skillp1 = victim.getActionManager().getSkill(MetarP1Info.getInstance());
+        skillp1.addValue(-speed * MetarP1Info.DECREASE_MULTIPLIER);
     }
 
     @Override

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarA1.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarA1.java
@@ -183,7 +183,7 @@ public final class MetarA1 extends ActiveSkill {
                 double damage = CombatUtil.getDistantDamage(MetarA1Info.DAMAGE_EXPLODE, center.distance(location), radius / 2.0);
 
                 if (target.getDamageModule().damage(MetarA1Projectile.this, damage, DamageType.NORMAL, null, false, true)
-                        && target instanceof Movable && !MetarA1Projectile.this.getHitTargets().contains(target)) {
+                        && target != combatUser && target instanceof Movable && !MetarA1Projectile.this.getHitTargets().contains(target)) {
                     Vector dir = LocationUtil.getDirection(center, location.add(0, 0.5, 0)).multiply(MetarA1Info.KNOCKBACK);
                     ((Movable) target).getMoveModule().knockback(dir);
                 }

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarA2Info.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarA2Info.java
@@ -17,13 +17,13 @@ public final class MetarA2Info extends ActiveSkillInfo<MetarA2> {
     /** 쿨타임 */
     public static final Timespan COOLDOWN = Timespan.ofSeconds(0.5);
     /** 스택 충전 쿨타임 */
-    public static final Timespan STACK_COOLDOWN = Timespan.ofSeconds(7);
+    public static final Timespan STACK_COOLDOWN = Timespan.ofSeconds(8);
     /** 최대 스택 충전량 */
     public static final int MAX_STACK = 2;
     /** 체력 */
     public static final int HEALTH = 1000;
     /** 지속시간 */
-    public static final Timespan DURATION = Timespan.ofSeconds(14);
+    public static final Timespan DURATION = Timespan.ofSeconds(10);
 
     /** 방어 점수 */
     public static final int BLOCK_SCORE = 20;

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarA2Info.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarA2Info.java
@@ -43,6 +43,7 @@ public final class MetarA2Info extends ActiveSkillInfo<MetarA2> {
                         new ActionInfoLore.NamedSection("에너지 방벽", ActionInfoLore.Section
                                 .builder("공격을 막는 고정형 방벽입니다.")
                                 .addValueInfo(TextIcon.HEALTH, HEALTH)
+                                .addValueInfo(TextIcon.DURATION, Format.TIME, DURATION.toSeconds())
                                 .build())));
     }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarA3.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarA3.java
@@ -176,7 +176,7 @@ public final class MetarA3 extends ActiveSkill implements HasBonusScore {
 
         private final class MetarA3Area extends Area<Damageable> {
             private MetarA3Area() {
-                super(combatUser, MetarA3Info.RADIUS, EntityCondition.enemy(combatUser).include(combatUser));
+                super(combatUser, MetarA3Info.RADIUS, MetarA3Projectile.this.entityCondition);
             }
 
             @Override

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarP1.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarP1.java
@@ -6,16 +6,19 @@ import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.skill.AbstractSkill;
 import com.dace.dmgr.combat.entity.combatuser.CombatUser;
 import com.dace.dmgr.combat.entity.module.AbilityStatus;
+import com.dace.dmgr.combat.entity.module.statuseffect.StatusEffectType;
 import com.dace.dmgr.util.task.IntervalTask;
 import lombok.NonNull;
-import org.jetbrains.annotations.Nullable;
 
 public final class MetarP1 extends AbstractSkill {
+    /** 중기갑 */
+    private double heavyArmor = MetarP1Info.MAX;
     /** 수정자 */
-    private static final AbilityStatus.Modifier MODIFIER = new AbilityStatus.Modifier(100);
+    private final AbilityStatus.Modifier modifier = new AbilityStatus.Modifier(MetarP1Info.KNOCKBACK_RESISTANCE_INCREMENT * heavyArmor);
 
     public MetarP1(@NonNull CombatUser combatUser) {
-        super(combatUser, MetarP1Info.getInstance(), MetarP1Info.COOLDOWN, Timespan.MAX);
+        super(combatUser, MetarP1Info.getInstance(), Timespan.ZERO, Timespan.MAX);
+        addOnReset(() -> heavyArmor = MetarP1Info.MAX);
     }
 
     @Override
@@ -25,14 +28,9 @@ public final class MetarP1 extends AbstractSkill {
     }
 
     @Override
-    @Nullable
+    @NonNull
     public String getActionBarString() {
-        if (!isCooldownFinished())
-            return ActionBarStringUtil.getCooldownBar(this);
-        else if (!isDurationFinished())
-            return skillInfo + " §a활성화";
-
-        return null;
+        return ActionBarStringUtil.getProgressBar(skillInfo.toString(), (int) heavyArmor, MetarP1Info.MAX);
     }
 
     @Override
@@ -43,23 +41,29 @@ public final class MetarP1 extends AbstractSkill {
     @Override
     public void onUse(@NonNull ActionKey actionKey) {
         setDuration();
-        combatUser.getMoveModule().getResistanceStatus().addModifier(MODIFIER);
+        combatUser.getMoveModule().getResistanceStatus().addModifier(modifier);
 
-        MetarP1Info.Sounds.USE.play(combatUser.getLocation());
-
-        addActionTask(new IntervalTask(i -> combatUser.getEntity().isSneaking(), this::forceCancel, 1));
+        addActionTask(new IntervalTask(i -> !combatUser.getStatusEffectModule().hasType(StatusEffectType.SILENCE), this::forceCancel, 1));
     }
 
     @Override
     public boolean isCancellable() {
-        return combatUser.isDead();
+        return false;
     }
 
     @Override
     protected void onCancelled() {
-        setCooldown();
-        combatUser.getMoveModule().getResistanceStatus().removeModifier(MODIFIER);
+        setDuration(Timespan.ZERO);
+        combatUser.getMoveModule().getResistanceStatus().removeModifier(modifier);
+    }
 
-        MetarP1Info.Sounds.DISABLE.play(combatUser.getLocation());
+    /**
+     * 중기갑 수치를 증가시킨다.
+     *
+     * @param amount 증가량
+     */
+    void addValue(double amount) {
+        heavyArmor = Math.min(MetarP1Info.MAX, Math.max(0, heavyArmor + amount));
+        modifier.setIncrement(MetarP1Info.KNOCKBACK_RESISTANCE_INCREMENT * heavyArmor);
     }
 }

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarP1Info.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarP1Info.java
@@ -1,42 +1,31 @@
 package com.dace.dmgr.combat.combatant.metar;
 
-import com.dace.dmgr.Timespan;
-import com.dace.dmgr.combat.action.ActionKey;
 import com.dace.dmgr.combat.action.TextIcon;
 import com.dace.dmgr.combat.action.info.ActionInfoLore;
-import com.dace.dmgr.combat.action.info.ActionInfoLore.Section.Format;
 import com.dace.dmgr.combat.action.info.PassiveSkillInfo;
-import com.dace.dmgr.effect.SoundEffect;
 import lombok.Getter;
-import lombok.experimental.UtilityClass;
-import org.bukkit.Sound;
 
 public final class MetarP1Info extends PassiveSkillInfo<MetarP1> {
-    /** 쿨타임 */
-    public static final Timespan COOLDOWN = Timespan.ofSeconds(0.5);
+    /** 넉백 저항 증가량 */
+    public static final double KNOCKBACK_RESISTANCE_INCREMENT = 0.8;
+    /** 감소량 배수 */
+    public static final double DECREASE_MULTIPLIER = 40;
+    /** 최대치 */
+    public static final int MAX = 100;
+    /** 초당 충전량 */
+    public static final int RECOVER_PER_SECOND = 7;
+
     @Getter
     private static final MetarP1Info instance = new MetarP1Info();
 
     private MetarP1Info() {
         super(MetarP1.class, "중기갑",
                 new ActionInfoLore(ActionInfoLore.Section
-                        .builder("웅크리기 상태일 때 <:KNOCKBACK:밀쳐내기> 효과를 받지 않습니다.")
-                        .addValueInfo(TextIcon.COOLDOWN, Format.TIME, COOLDOWN.toSeconds())
-                        .addActionKeyInfo("사용", ActionKey.SNEAK)
+                        .builder("수치에 비례하여 <:KNOCKBACK:밀쳐내기> 효과를 적게 받습니다. 적에 의해 밀려나면 감소합니다. " +
+                                "자신의 밀쳐내기 효과는 받지 않습니다.")
+                        .addValueInfo(TextIcon.UNDEFINED, "최대 {0}", MAX)
+                        .addValueInfo(TextIcon.UNDEFINED, "초당 +{0}%", RECOVER_PER_SECOND)
+                        .addValueInfo(TextIcon.KNOCKBACK, "(중기갑)×{0}", KNOCKBACK_RESISTANCE_INCREMENT)
                         .build()));
-    }
-
-    /**
-     * 효과음 정보.
-     */
-    @UtilityClass
-    public static final class Sounds {
-        /** 사용 */
-        public static final SoundEffect USE = new SoundEffect(
-                SoundEffect.SoundInfo.builder(Sound.ENTITY_PLAYER_HURT).volume(0.8).pitch(0.5).build(),
-                SoundEffect.SoundInfo.builder(Sound.BLOCK_STONE_STEP).volume(0.8).pitch(0.7).build());
-        /** 해제 */
-        public static final SoundEffect DISABLE = new SoundEffect(
-                SoundEffect.SoundInfo.builder(Sound.ENTITY_IRONGOLEM_STEP).volume(0.8).pitch(1.6).build());
     }
 }

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarP1Info.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarP1Info.java
@@ -25,7 +25,7 @@ public final class MetarP1Info extends PassiveSkillInfo<MetarP1> {
                                 "자신의 밀쳐내기 효과는 받지 않습니다.")
                         .addValueInfo(TextIcon.UNDEFINED, "최대 {0}", MAX)
                         .addValueInfo(TextIcon.UNDEFINED, "초당 +{0}%", RECOVER_PER_SECOND)
-                        .addValueInfo(TextIcon.KNOCKBACK, "(중기갑)×{0}", KNOCKBACK_RESISTANCE_INCREMENT)
+                        .addValueInfo(TextIcon.KNOCKBACK, "(중기갑)×{0}%", KNOCKBACK_RESISTANCE_INCREMENT)
                         .build()));
     }
 }

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarWeapon.java
@@ -167,7 +167,7 @@ public final class MetarWeapon extends AbstractWeapon implements Reloadable, Ful
         @NonNull
         protected HitEntityHandler<Damageable> getHitEntityHandler() {
             return (location, target) -> {
-                double damage = CombatUtil.getDistantDamage(MetarWeaponInfo.DAMAGE, getTravelDistance(), MetarWeaponInfo.DAMAGE_WEAKENING_DISTANCE);
+                double damage = CombatUtil.getDistantDamage(MetarWeaponInfo.DAMAGE, getTravelDistance(), MetarWeaponInfo.DISTANCE / 2.0);
 
                 target.getDamageModule().damage(combatUser, damage, DamageType.NORMAL, location, false, true);
                 return false;

--- a/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/metar/MetarWeaponInfo.java
@@ -20,11 +20,9 @@ public final class MetarWeaponInfo extends WeaponInfo<MetarWeapon> {
     /** 연사속도 */
     public static final FullAuto.FireRate FIRE_RATE = FullAuto.FireRate.RPM_840;
     /** 피해량 */
-    public static final int DAMAGE = 30;
-    /** 피해량 감소 시작 거리 (단위: 블록) */
-    public static final int DAMAGE_WEAKENING_DISTANCE = 12;
+    public static final int DAMAGE = 25;
     /** 사거리 (단위: 블록) */
-    public static final int DISTANCE = 24;
+    public static final int DISTANCE = 30;
     /** 투사체 속력 (단위: 블록/s) */
     public static final int VELOCITY = 60;
     /** 탄퍼짐 */
@@ -46,7 +44,7 @@ public final class MetarWeaponInfo extends WeaponInfo<MetarWeapon> {
                 new ActionInfoLore(ActionInfoLore.Section
                         .builder("대용량 탄창이 장착된 에너지 기관포입니다. 사격하여 <:DAMAGE:피해>를 입힙니다.")
                         .addValueInfo(TextIcon.DAMAGE, Format.VARIABLE_WITH_DISTANCE,
-                                DAMAGE, DAMAGE / 2, DAMAGE_WEAKENING_DISTANCE, DAMAGE_WEAKENING_DISTANCE * 2)
+                                DAMAGE, DAMAGE / 2, DISTANCE / 2, DISTANCE)
                         .addValueInfo(TextIcon.ATTACK_SPEED, Format.TIME_WITH_RPM,
                                 60.0 / FIRE_RATE.getRoundsPerMinute(), FIRE_RATE.getRoundsPerMinute())
                         .addValueInfo(TextIcon.DISTANCE, Format.DISTANCE, DISTANCE)

--- a/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA1.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA1.java
@@ -118,15 +118,16 @@ public final class NeaceA1 extends ActiveSkill implements Targeted<Healable> {
 
         @Override
         public void onTick(@NonNull Damageable combatEntity, long i) {
-            NeaceA1Info.Particles.MARK.play(combatEntity.getLocation().add(0, combatEntity.getHeight() + 0.5, 0));
-
-            if (!(combatEntity instanceof Healable) || ((Healable) combatEntity).getDamageModule().isFullHealth())
-                return;
+            NeaceA1Info.Particles.MARK.play(combatEntity.getLocation().add(0, combatEntity.getHeight() + 0.8, 0));
 
             if (provider == null || provider.isRemoved()) {
                 combatEntity.getStatusEffectModule().remove(this);
                 return;
             }
+
+            if (!(combatEntity instanceof Healable) || ((Healable) combatEntity).getDamageModule().isFullHealth()
+                    || ((NeaceWeapon) provider.getActionManager().getWeapon()).isHealing((Healable) combatEntity))
+                return;
 
             double amount = NeaceA1Info.HEAL_PER_SECOND / 20.0;
             if (((Healable) combatEntity).getDamageModule().heal(provider, amount, true))

--- a/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA1Info.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA1Info.java
@@ -33,7 +33,8 @@ public final class NeaceA1Info extends ActiveSkillInfo<NeaceA1> {
         super(NeaceA1.class, "구원의 표식",
                 new ActionInfoLore(ActionInfoLore.Section
                         .builder("바라보는 아군에게 표식을 남겨 일정 시간동안 <:HEAL:치유>합니다. " +
-                                "이미 표식이 있는 아군에게 사용할 수 없으며, 치유량이 최대치에 도달하거나 지속 시간이 지나면 사라집니다.")
+                                "이미 표식이 있는 아군에게 사용할 수 없으며, 치유량이 최대치에 도달하거나 지속 시간이 지나면 사라집니다. " +
+                                "기본 무기로 치유하고 있는 대상은 치유할 수 없습니다.")
                         .addValueInfo(TextIcon.COOLDOWN, Format.TIME, COOLDOWN.toSeconds())
                         .addValueInfo(TextIcon.DURATION, Format.TIME, DURATION.toSeconds())
                         .addValueInfo(TextIcon.HEAL, Format.PER_SECOND + " / 최대 {1}", HEAL_PER_SECOND, MAX_HEAL)

--- a/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA1Info.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA1Info.java
@@ -18,7 +18,7 @@ public final class NeaceA1Info extends ActiveSkillInfo<NeaceA1> {
     /** 쿨타임 */
     public static final Timespan COOLDOWN = Timespan.ofSeconds(10);
     /** 초당 치유량 */
-    public static final int HEAL_PER_SECOND = 250;
+    public static final int HEAL_PER_SECOND = 200;
     /** 최대 치유량 */
     public static final int MAX_HEAL = 1000;
     /** 최대 거리 (단위: 블록) */

--- a/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA2.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA2.java
@@ -3,7 +3,7 @@ package com.dace.dmgr.combat.combatant.neace;
 import com.dace.dmgr.Timespan;
 import com.dace.dmgr.combat.action.ActionBarStringUtil;
 import com.dace.dmgr.combat.action.ActionKey;
-import com.dace.dmgr.combat.action.skill.ActiveSkill;
+import com.dace.dmgr.combat.action.skill.ChargeableSkill;
 import com.dace.dmgr.combat.entity.Attacker;
 import com.dace.dmgr.combat.entity.Damageable;
 import com.dace.dmgr.combat.entity.Healable;
@@ -15,16 +15,15 @@ import com.dace.dmgr.util.task.IntervalTask;
 import lombok.NonNull;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.Nullable;
 
-public final class NeaceA2 extends ActiveSkill {
+public final class NeaceA2 extends ChargeableSkill {
     /** 공격력 수정자 */
     private static final AbilityStatus.Modifier DAMAGE_MODIFIER = new AbilityStatus.Modifier(NeaceA2Info.DAMAGE_INCREMENT);
     /** 방어력 수정자 */
     private static final AbilityStatus.Modifier DEFENSE_MODIFIER = new AbilityStatus.Modifier(NeaceA2Info.DEFENSE_INCREMENT);
 
     public NeaceA2(@NonNull CombatUser combatUser) {
-        super(combatUser, NeaceA2Info.getInstance(), NeaceA2Info.COOLDOWN, NeaceA2Info.DURATION, 1);
+        super(combatUser, NeaceA2Info.getInstance(), NeaceA2Info.COOLDOWN, NeaceA2Info.MAX_DURATION.toSeconds(), 1);
     }
 
     @Override
@@ -34,12 +33,23 @@ public final class NeaceA2 extends ActiveSkill {
     }
 
     @Override
-    @Nullable
+    @NonNull
     public String getActionBarString() {
-        if (isDurationFinished())
-            return null;
+        String text = ActionBarStringUtil.getDurationBar(this, Timespan.ofSeconds(getStateValue()), Timespan.ofSeconds(maxStateValue));
+        if (!isDurationFinished())
+            text += ActionBarStringUtil.getKeyInfo(this, "해제");
 
-        return ActionBarStringUtil.getDurationBar(this) + ActionBarStringUtil.getKeyInfo(this, "해제");
+        return text;
+    }
+
+    @Override
+    protected double getStateValueDecrement() {
+        return 1;
+    }
+
+    @Override
+    protected double getStateValueIncrement() {
+        return getMaxStateValue() / NeaceA2Info.RECOVER_DURATION.toSeconds();
     }
 
     @Override
@@ -55,26 +65,29 @@ public final class NeaceA2 extends ActiveSkill {
         NeaceA2Info.Sounds.USE.play(combatUser.getLocation());
 
         addActionTask(new IntervalTask(i -> {
-            NeaceA2Info.Particles.TICK.play(combatUser.getCenterLocation());
-            if (i < 12)
-                playUseTickEffect(i);
-        }, 1, NeaceA2Info.DURATION.toTicks()));
-    }
+            if (getStateValue() <= 0)
+                return false;
 
-    @Override
-    protected void onDurationFinished() {
-        super.onDurationFinished();
-        combatUser.getActionManager().getWeapon().setGlowing(false);
+            NeaceA2Info.Particles.TICK.play(combatUser.getCenterLocation());
+            if (i < 10)
+                playUseTickEffect(i);
+
+            return true;
+        }, this::forceCancel, 1));
     }
 
     @Override
     public boolean isCancellable() {
-        return combatUser.isDead();
+        return combatUser.isDead() && !isDurationFinished();
     }
 
     @Override
     protected void onCancelled() {
         setDuration(Timespan.ZERO);
+
+        combatUser.getActionManager().getWeapon().setGlowing(false);
+
+        NeaceA2Info.Sounds.DISABLE.play(combatUser.getLocation());
     }
 
     /**
@@ -95,7 +108,7 @@ public final class NeaceA2 extends ActiveSkill {
             double up = (i * 4 + j) * 0.05;
             Vector vec = VectorUtil.getRotatedVector(vector, axis, angle);
 
-            NeaceA2Info.Particles.USE_TICK.play(loc.clone().add(vec).add(0, up, 0), i / 11.0);
+            NeaceA2Info.Particles.USE_TICK.play(loc.clone().add(vec).add(0, up, 0), i / 9.0);
         }
     }
 

--- a/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA2Info.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceA2Info.java
@@ -15,13 +15,15 @@ import org.bukkit.Sound;
 
 public final class NeaceA2Info extends ActiveSkillInfo<NeaceA2> {
     /** 쿨타임 */
-    public static final Timespan COOLDOWN = Timespan.ofSeconds(7);
+    public static final Timespan COOLDOWN = Timespan.ofSeconds(1);
     /** 공격력 증가량 */
     public static final int DAMAGE_INCREMENT = 15;
     /** 방어력 증가량 */
     public static final int DEFENSE_INCREMENT = 15;
-    /** 지속시간 */
-    public static final Timespan DURATION = Timespan.ofSeconds(8);
+    /** 최대 지속시간 */
+    public static final Timespan MAX_DURATION = Timespan.ofSeconds(8);
+    /** 최대 충전 시간 */
+    public static final Timespan RECOVER_DURATION = Timespan.ofSeconds(6);
 
     /** 처치 지원 점수 */
     public static final int ASSIST_SCORE = 20;
@@ -34,7 +36,7 @@ public final class NeaceA2Info extends ActiveSkillInfo<NeaceA2> {
                 new ActionInfoLore(ActionInfoLore.Section
                         .builder("일정 시간동안 기본 무기의 치유 대상을 <3::축복>할 수 있습니다. " +
                                 "사용 중에는 기본 무기로 치유할 수 없습니다.")
-                        .addValueInfo(TextIcon.DURATION, Format.TIME, DURATION.toSeconds())
+                        .addValueInfo(TextIcon.DURATION, Format.TIME_WITH_MAX_TIME, MAX_DURATION.toSeconds(), RECOVER_DURATION.toSeconds())
                         .addActionKeyInfo("사용", ActionKey.SLOT_2)
                         .build(),
                         new ActionInfoLore.NamedSection("축복", ActionInfoLore.Section
@@ -42,7 +44,7 @@ public final class NeaceA2Info extends ActiveSkillInfo<NeaceA2> {
                                 .addValueInfo(TextIcon.DAMAGE_INCREASE, Format.PERCENT, DAMAGE_INCREMENT)
                                 .addValueInfo(TextIcon.DEFENSE_INCREASE, Format.PERCENT, DEFENSE_INCREMENT)
                                 .build()),
-                        new ActionInfoLore.NamedSection("지속시간 종료/재사용 시", ActionInfoLore.Section
+                        new ActionInfoLore.NamedSection("재사용 시", ActionInfoLore.Section
                                 .builder("사용을 종료합니다.")
                                 .addValueInfo(TextIcon.COOLDOWN, Format.TIME, COOLDOWN.toSeconds())
                                 .addActionKeyInfo("해제", ActionKey.SLOT_2)
@@ -60,6 +62,9 @@ public final class NeaceA2Info extends ActiveSkillInfo<NeaceA2> {
                 SoundEffect.SoundInfo.builder(Sound.BLOCK_ENCHANTMENT_TABLE_USE).volume(2).pitch(1.4).build(),
                 SoundEffect.SoundInfo.builder(Sound.BLOCK_ENCHANTMENT_TABLE_USE).volume(2).pitch(1.4).build(),
                 SoundEffect.SoundInfo.builder(Sound.ENTITY_ZOMBIE_VILLAGER_CONVERTED).volume(0.5).pitch(1.4).build());
+        /** 해제 */
+        public static final SoundEffect DISABLE = new SoundEffect(
+                SoundEffect.SoundInfo.builder(Sound.ENTITY_EVOCATION_ILLAGER_CAST_SPELL).volume(1).pitch(1.8).build());
     }
 
     /**

--- a/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceWeapon.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceWeapon.java
@@ -12,7 +12,6 @@ import com.dace.dmgr.combat.entity.Damageable;
 import com.dace.dmgr.combat.entity.EntityCondition;
 import com.dace.dmgr.combat.entity.Healable;
 import com.dace.dmgr.combat.entity.combatuser.CombatUser;
-import com.dace.dmgr.combat.entity.module.statuseffect.ValueStatusEffect;
 import com.dace.dmgr.combat.interaction.Projectile;
 import com.dace.dmgr.combat.interaction.Target;
 import com.dace.dmgr.util.location.LocationUtil;
@@ -70,9 +69,8 @@ public final class NeaceWeapon extends AbstractWeapon implements FullAuto {
             case RIGHT_CLICK: {
                 if (target != null && (!target.canBeTargeted() || target.isRemoved() || targetResetTimestamp.isBefore(Timestamp.now())
                         || blockResetTimestamp.isBefore(Timestamp.now())
-                        || combatUser.getEntity().getEyeLocation().distance(target.getCenterLocation()) > NeaceWeaponInfo.Heal.MAX_DISTANCE)) {
+                        || combatUser.getEntity().getEyeLocation().distance(target.getCenterLocation()) > NeaceWeaponInfo.Heal.MAX_DISTANCE))
                     target = null;
-                }
 
                 if (target == null)
                     new NeaceWeaponRTarget().shot();
@@ -113,11 +111,21 @@ public final class NeaceWeapon extends AbstractWeapon implements FullAuto {
 
         if (isAmplifying)
             skill2.amplifyTarget(target);
-        else if (!target.getStatusEffectModule().has(ValueStatusEffect.Type.HEALING_MARK))
+        else
             target.getDamageModule().heal(combatUser, NeaceWeaponInfo.Heal.HEAL_PER_SECOND / 20.0, true);
 
         for (Location loc : LocationUtil.getLine(combatUser.getArmLocation(MainHand.RIGHT), target.getCenterLocation(), 0.8))
             (isAmplifying ? NeaceWeaponInfo.Particles.HIT_ENTITY_HEAL_AMPLIFY : NeaceWeaponInfo.Particles.HIT_ENTITY_HEAL).play(loc);
+    }
+
+    /**
+     * 대상이 치유를 받고 있는지 확인한다.
+     *
+     * @param target 확인할 대상
+     * @return 치유를 받고 있으면 {@code true} 반환
+     */
+    boolean isHealing(@NonNull Healable target) {
+        return this.target == target && targetResetTimestamp.isAfter(Timestamp.now());
     }
 
     private final class NeaceWeaponRTarget extends Target<Healable> {

--- a/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/neace/NeaceWeaponInfo.java
@@ -42,8 +42,7 @@ public final class NeaceWeaponInfo extends WeaponInfo<NeaceWeapon> {
                                 .addValueInfo(TextIcon.DISTANCE, Format.DISTANCE, DISTANCE)
                                 .build()),
                         new ActionInfoLore.NamedSection("치유 광선", ActionInfoLore.Section
-                                .builder("바라보는 아군에게 치유 광선을 고정하여 지속적으로 <:HEAL:치유>합니다. " +
-                                        "<d::구원의 표식>이 있는 아군은 치유할 수 없습니다.")
+                                .builder("바라보는 아군에게 치유 광선을 고정하여 지속적으로 <:HEAL:치유>합니다.")
                                 .addValueInfo(TextIcon.HEAL, Format.PER_SECOND, Heal.HEAL_PER_SECOND)
                                 .addValueInfo(TextIcon.DISTANCE, Format.DISTANCE, Heal.MAX_DISTANCE)
                                 .build())));

--- a/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasWeaponInfo.java
+++ b/src/main/java/com/dace/dmgr/combat/combatant/palas/PalasWeaponInfo.java
@@ -27,7 +27,7 @@ public final class PalasWeaponInfo extends WeaponInfo<PalasWeapon> {
     /** 치유량 */
     public static final int HEAL = 300;
     /** 치유 투사체 크기 (단위: 블록) */
-    public static final double HEAL_SIZE = 0.2;
+    public static final double HEAL_SIZE = 0.16;
     /** 사거리 (단위: 블록) */
     public static final int DISTANCE = 30;
     /** 장탄수 */

--- a/src/main/java/com/dace/dmgr/combat/entity/module/MoveModule.java
+++ b/src/main/java/com/dace/dmgr/combat/entity/module/MoveModule.java
@@ -5,6 +5,7 @@ import com.dace.dmgr.Timestamp;
 import com.dace.dmgr.combat.entity.CombatRestriction;
 import com.dace.dmgr.combat.entity.Damageable;
 import com.dace.dmgr.combat.entity.Movable;
+import com.dace.dmgr.combat.entity.combatuser.CombatUser;
 import com.dace.dmgr.util.EntityUtil;
 import lombok.Getter;
 import lombok.NonNull;
@@ -151,8 +152,11 @@ public final class MoveModule {
     public void knockback(@NonNull Vector velocity, boolean isReset) {
         knockbackTimestamp = Timestamp.now().plus(Timespan.ofTicks(3));
 
-        Vector finalVelocity = velocity.multiply(Math.max(0, 2 - resistanceStatus.getValue()));
+        Vector finalVelocity = velocity.clone().multiply(Math.max(0, 2 - resistanceStatus.getValue()));
         combatEntity.getEntity().setVelocity(isReset ? finalVelocity : combatEntity.getEntity().getVelocity().add(finalVelocity));
+
+        if (combatEntity instanceof CombatUser)
+            ((CombatUser) combatEntity).getCombatantType().getCombatant().onKnockbacked((CombatUser) combatEntity, velocity.length());
     }
 
     /**


### PR DESCRIPTION
## 역할 - 돌격

### 공용 특성 1번
- 넉백 저항 30% -> 25%

## 역할 - 수호

### 공용 특성 1번
- 넉백 저항 30% -> 25%

## 예거

### MK.73 ELNR `무기`
- 냉각탄 `좌클릭`
  - 피해량 70 -> 100

## METAR

### 펄스 쌍기관포 `무기`
- 피해량 30 - 15 (12m-24m) -> 25 - 13 (15m-30m)

### 중기갑 `패시브 1번`
- 조건 변경 : 항상 발동
- 저항 게이지 추가 - 수치에 비례하여 넉백 저항력이 증가함 (최대 100%)
- 적에게 밀쳐졌을 때 밀쳐내기 강도에 비례하여 저항 게이지가 감소됨
- 초당 7% 회복

### 에너지 방벽 `액티브 2번`
- 쿨타임 7초 -> 8초
- 지속시간 14초 -> 10초

## 팔라스

### RQ-07 `무기`
- 투사체 크기 0.2 -> 0.16

## 니스

### 구원의 표식 `액티브 1번`
- 치유량 250/초 -> 200/초
- 기본 무기의 치유를 우선적으로 적용

### 축복 `액티브 2번`
- 충전형으로 변경